### PR TITLE
Fix length bug in import structures

### DIFF
--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -709,10 +709,10 @@ class StructuresIntegrator(LinearStructuresImporter):
                 if not structure_buffer.intersects(channel_geometry):
                     continue
                 intersection_m = channel_geometry.lineLocatePoint(structure_geom)
-                structure_length = getattr(
-                    structure_feat,
-                    self.conversion_settings.length_source_field,
-                    self.conversion_settings.length_fallback_value,
+                structure_length = (
+                    structure_feat[self.conversion_settings.length_source_field]
+                    if self.conversion_settings.length_source_field
+                    else self.conversion_settings.length_fallback_value
                 )
             else:
                 continue


### PR DESCRIPTION
When importing structures, the length field was not used correctly; instead, the fallback value was always used.

This small edit fixes it.