### PR TITLE
Display any UserWarning raised during schema upgrade

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 2.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Display upgrade warnings (any UserWarning raised during upgrading)
 
 
 2.1 (2025-04-02)


### PR DESCRIPTION
Display any `UserWarning` that is raised during `schema.upgrade`. I choose to use the generic `UserWarning` instead of importing the specific warnings because those warnings are scattered over the upgrades. If we want to use the specific warnings that threedi-schema raises, I propose to move all upgrade warnings to a single file so they can easily be imported. 

![Screenshot from 2025-03-31 10-43-03](https://github.com/user-attachments/assets/037bbd1e-c11d-4e57-8092-3b5a125124b1)
