### PR TITLE
Fix import order in __init__.py

### DIFF
--- a/threedi_schematisation_editor/__init__.py
+++ b/threedi_schematisation_editor/__init__.py
@@ -10,12 +10,15 @@ from qgis.PyQt.QtWidgets import QAction, QComboBox, QDialog, QMenu
 
 PLUGIN_DIR = Path(__file__).parent
 
-from threedi_schema import ThreediDatabase
 
 from threedi_schematisation_editor.deps.custom_imports import \
     patch_wheel_imports
 
+# Make sure to run this before importing anything from plugin dependencies!
 patch_wheel_imports()
+
+from threedi_schema import ThreediDatabase
+
 from threedi_mi_utils.news import QgsNewsSettingsInjector
 
 import threedi_schematisation_editor.data_models as dm


### PR DESCRIPTION
Importing any dependency from `deps` should be done after importing and running `patch_wheel_imports`. If this is done in another other, imports break!