### PR TITLE
Safe duplicate features styling

### DIFF
--- a/threedi_schematisation_editor/styles/vector/general/labeling/default.qml
+++ b/threedi_schematisation_editor/styles/vector/general/labeling/default.qml
@@ -1,127 +1,152 @@
-<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <labeling type="none"> <!-- "none" is an invalid value, which tricks qgis into switching to "no labels"-->
+<?xml version='1.0' encoding='utf-8'?>
+<qgis><labeling type="simple">
     <settings calloutType="simple">
-      <text-style blendMode="0" fontLetterSpacing="0" fieldName="id" textColor="0,0,0,255" fontWeight="50" fontStrikeout="0" fontWordSpacing="0" previewBkgrdColor="255,255,255,255" capitalization="0" multilineHeightUnit="Percentage" useSubstitutions="0" multilineHeight="1" forcedBold="0" forcedItalic="0" fontItalic="0" legendString="Aa" allowHtml="0" fontUnderline="0" namedStyle="Regular" fontSizeUnit="Point" fontSize="8" fontFamily="MS Gothic" fontSizeMapUnitScale="3x:0,0,0,0,0,0" isExpression="0" fontKerning="1" textOpacity="1" textOrientation="horizontal">
-        <families/>
-        <text-buffer bufferNoFill="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="64" bufferSize="0.59999999999999998" bufferBlendMode="0" bufferColor="255,255,255,255" bufferSizeUnits="MM" bufferDraw="1" bufferOpacity="1"/>
-        <text-mask maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskJoinStyle="128" maskType="0" maskOpacity="1" maskedSymbolLayers="" maskSize="0" maskEnabled="0"/>
-        <background shapeFillColor="255,255,255,255" shapeOffsetX="0" shapeBorderColor="128,128,128,255" shapeType="0" shapeBlendMode="0" shapeRadiiUnit="MM" shapeDraw="0" shapeOffsetY="0" shapeSizeUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeOpacity="1" shapeRotationType="0" shapeJoinStyle="64" shapeRadiiY="0" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeSVGFile="">
-          <symbol clip_to_extent="1" type="marker" alpha="1" force_rhr="0" name="markerSymbol" frame_rate="10" is_animated="0">
+      <text-style fontKerning="1" useSubstitutions="0" fontFamily="MS Shell Dlg 2" allowHtml="0" forcedItalic="0" blendMode="0" fontWeight="75" fieldName="if ( map_get(from_json(@nr_editable_layers ), @schematisation_uuid) > 0, NULL, &#xd;&#xa;&#x9;with_variable(&#xd;&#xa;&#x9;&#x9;'nr_intersections',&#xd;&#xa;&#x9;&#x9;array_length(overlay_equals(layer:=@layer, expression:= geom_to_wkt(@geometry))),&#xd;&#xa;&#x9;&#x9;if(@nr_intersections>0,@nr_intersections + 1,NULL)&#xd;&#xa;&#x9;)&#xd;&#xa;)" textOrientation="horizontal" previewBkgrdColor="255,255,255,255" fontItalic="0" multilineHeightUnit="Percentage" fontSize="10" fontStrikeout="0" textColor="60,60,60,255" fontSizeUnit="Point" multilineHeight="1" fontUnderline="0" namedStyle="Bold" forcedBold="0" isExpression="1" legendString="Aa" capitalization="0" textOpacity="1" fontLetterSpacing="0" fontWordSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0">
+        <families />
+        <text-buffer bufferBlendMode="0" bufferDraw="1" bufferSizeUnits="MM" bufferOpacity="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255" bufferNoFill="0" bufferSize="0.69999999999999996" bufferJoinStyle="128" />
+        <text-mask maskSizeUnits="MM" maskedSymbolLayers="" maskSize="0" maskType="0" maskOpacity="1" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskJoinStyle="128" maskEnabled="0" />
+        <background shapeRotationType="0" shapeBorderWidth="0" shapeType="5" shapeOffsetY="0" shapeSizeUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeSizeY="0" shapeDraw="1" shapeFillColor="255,255,255,255" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeJoinStyle="64" shapeSVGFile="" shapeOffsetX="0" shapeSizeX="0" shapeRadiiX="0" shapeOpacity="1" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeOffsetUnit="MM" shapeRadiiUnit="MM">
+          <symbol frame_rate="10" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker" alpha="1" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" value="" type="QString" />
+                <Option name="properties" />
+                <Option name="type" value="collection" type="QString" />
               </Option>
             </data_defined_properties>
-            <layer class="SimpleMarker" pass="0" locked="0" id="" enabled="1">
+            <layer locked="0" id="" pass="0" class="SimpleMarker" enabled="1">
               <Option type="Map">
-                <Option type="QString" value="0" name="angle"/>
-                <Option type="QString" value="square" name="cap_style"/>
-                <Option type="QString" value="125,139,143,255" name="color"/>
-                <Option type="QString" value="1" name="horizontal_anchor_point"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="circle" name="name"/>
-                <Option type="QString" value="0,0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="35,35,35,255" name="outline_color"/>
-                <Option type="QString" value="solid" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="diameter" name="scale_method"/>
-                <Option type="QString" value="2" name="size"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-                <Option type="QString" value="MM" name="size_unit"/>
-                <Option type="QString" value="1" name="vertical_anchor_point"/>
+                <Option name="angle" value="0" type="QString" />
+                <Option name="cap_style" value="square" type="QString" />
+                <Option name="color" value="255,255,255,255" type="QString" />
+                <Option name="horizontal_anchor_point" value="1" type="QString" />
+                <Option name="joinstyle" value="bevel" type="QString" />
+                <Option name="name" value="circle" type="QString" />
+                <Option name="offset" value="0,0" type="QString" />
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString" />
+                <Option name="offset_unit" value="MM" type="QString" />
+                <Option name="outline_color" value="60,60,60,255" type="QString" />
+                <Option name="outline_style" value="solid" type="QString" />
+                <Option name="outline_width" value="0.4" type="QString" />
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString" />
+                <Option name="outline_width_unit" value="MM" type="QString" />
+                <Option name="scale_method" value="diameter" type="QString" />
+                <Option name="size" value="4" type="QString" />
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString" />
+                <Option name="size_unit" value="MM" type="QString" />
+                <Option name="vertical_anchor_point" value="1" type="QString" />
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" value="" type="QString" />
+                  <Option name="properties" />
+                  <Option name="type" value="collection" type="QString" />
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol clip_to_extent="1" type="fill" alpha="1" force_rhr="0" name="fillSymbol" frame_rate="10" is_animated="0">
+          <symbol frame_rate="10" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill" alpha="1" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
-                <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="name" value="" type="QString" />
+                <Option name="properties" />
+                <Option name="type" value="collection" type="QString" />
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" pass="0" locked="0" id="" enabled="1">
+            <layer locked="0" id="" pass="0" class="SimpleFill" enabled="1">
               <Option type="Map">
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-                <Option type="QString" value="255,255,255,255" name="color"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="0,0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="128,128,128,255" name="outline_color"/>
-                <Option type="QString" value="no" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="solid" name="style"/>
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString" />
+                <Option name="color" value="255,255,255,255" type="QString" />
+                <Option name="joinstyle" value="bevel" type="QString" />
+                <Option name="offset" value="0,0" type="QString" />
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString" />
+                <Option name="offset_unit" value="MM" type="QString" />
+                <Option name="outline_color" value="128,128,128,255" type="QString" />
+                <Option name="outline_style" value="no" type="QString" />
+                <Option name="outline_width" value="0" type="QString" />
+                <Option name="outline_width_unit" value="MM" type="QString" />
+                <Option name="style" value="solid" type="QString" />
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
-                  <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="name" value="" type="QString" />
+                  <Option name="properties" />
+                  <Option name="type" value="collection" type="QString" />
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </background>
-        <shadow shadowRadiusAlphaOnly="0" shadowRadiusUnit="MM" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowOffsetGlobal="1" shadowOffsetAngle="135" shadowOffsetUnit="MM" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowBlendMode="6" shadowColor="0,0,0,255" shadowScale="100" shadowUnder="0" shadowDraw="0" shadowRadius="1.5"/>
+        <shadow shadowOffsetDist="1" shadowRadius="1.5" shadowBlendMode="6" shadowUnder="0" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowRadiusAlphaOnly="0" shadowOpacity="0.69999999999999996" shadowDraw="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusUnit="MM" />
         <dd_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="name" value="" type="QString" />
+            <Option name="properties" />
+            <Option name="type" value="collection" type="QString" />
           </Option>
         </dd_properties>
-        <substitutions/>
+        <substitutions />
       </text-style>
-      <text-format reverseDirectionSymbol="0" placeDirectionSymbol="0" plussign="0" leftDirectionSymbol="&lt;" decimals="3" formatNumbers="0" useMaxLineLengthForAutoWrap="1" addDirectionSymbol="0" multilineAlign="0" wrapChar="" rightDirectionSymbol=">" autoWrapLength="0"/>
-      <placement dist="0" geometryGenerator="" centroidWhole="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" polygonPlacementFlags="2" xOffset="0" overlapHandling="PreventOverlap" maxCurvedCharAngleIn="20" placement="0" geometryGeneratorEnabled="0" preserveRotation="1" geometryGeneratorType="PointGeometry" overrunDistance="0" centroidInside="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" fitInPolygonOnly="0" offsetUnits="MapUnit" yOffset="0" allowDegraded="0" distUnits="MM" repeatDistanceUnits="MM" lineAnchorClipping="0" lineAnchorType="0" lineAnchorPercent="0.5" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="0" maxCurvedCharAngleOut="-20" distMapUnitScale="3x:0,0,0,0,0,0" priority="5" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" offsetType="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" quadOffset="4" rotationAngle="0" repeatDistance="0"/>
-      <rendering drawLabels="1" scaleMin="0" obstacle="1" limitNumLabels="0" upsidedownLabels="0" scaleMax="0" fontMinPixelSize="3" scaleVisibility="0" mergeLines="0" obstacleType="0" minFeatureSize="0" fontMaxPixelSize="10000" zIndex="0" maxNumLabels="2000" unplacedVisibility="0" labelPerPart="0" obstacleFactor="1" fontLimitPixelSize="0"/>
+      <text-format multilineAlign="0" useMaxLineLengthForAutoWrap="1" wrapChar="" autoWrapLength="0" rightDirectionSymbol="&gt;" addDirectionSymbol="0" plussign="0" formatNumbers="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" decimals="3" placeDirectionSymbol="0" />
+      <placement preserveRotation="0" lineAnchorTextPoint="CenterOfText" overrunDistance="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" distMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" lineAnchorPercent="0.5" geometryGenerator="centroid($geometry)" layerType="LineGeometry" overrunDistanceUnit="MM" fitInPolygonOnly="0" maxCurvedCharAngleOut="-25" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" priority="5" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" polygonPlacementFlags="2" offsetType="0" dist="0" repeatDistanceUnits="MM" geometryGeneratorType="PointGeometry" offsetUnits="MM" geometryGeneratorEnabled="1" xOffset="4" centroidInside="0" placement="1" lineAnchorType="0" overlapHandling="AllowOverlapIfRequired" allowDegraded="1" quadOffset="2" repeatDistance="0" rotationUnit="AngleDegrees" centroidWhole="0" rotationAngle="0" lineAnchorClipping="0" yOffset="-4" placementFlags="2" />
+      <rendering limitNumLabels="0" zIndex="0" upsidedownLabels="0" fontMaxPixelSize="10000" unplacedVisibility="0" fontMinPixelSize="3" labelPerPart="0" obstacle="1" fontLimitPixelSize="0" scaleVisibility="1" obstacleType="0" maxNumLabels="2000" minFeatureSize="0" drawLabels="1" scaleMax="2500" scaleMin="1" mergeLines="0" obstacleFactor="1" />
       <dd_properties>
         <Option type="Map">
-          <Option type="QString" value="" name="name"/>
-          <Option name="properties"/>
-          <Option type="QString" value="collection" name="type"/>
+          <Option name="name" value="" type="QString" />
+          <Option name="properties" type="Map">
+            <Option name="Hali" type="Map">
+              <Option name="active" value="true" type="bool" />
+              <Option name="expression" value="'Left'" type="QString" />
+              <Option name="type" value="3" type="int" />
+            </Option>
+            <Option name="LabelRotation" type="Map">
+              <Option name="active" value="false" type="bool" />
+              <Option name="type" value="1" type="int" />
+              <Option name="val" value="" type="QString" />
+            </Option>
+            <Option name="PositionX" type="Map">
+              <Option name="active" value="false" type="bool" />
+              <Option name="type" value="1" type="int" />
+              <Option name="val" value="" type="QString" />
+            </Option>
+            <Option name="PositionY" type="Map">
+              <Option name="active" value="false" type="bool" />
+              <Option name="type" value="1" type="int" />
+              <Option name="val" value="" type="QString" />
+            </Option>
+            <Option name="Vali" type="Map">
+              <Option name="active" value="true" type="bool" />
+              <Option name="expression" value="'Top'" type="QString" />
+              <Option name="type" value="3" type="int" />
+            </Option>
+          </Option>
+          <Option name="type" value="collection" type="QString" />
         </Option>
       </dd_properties>
       <callout type="simple">
         <Option type="Map">
-          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
-          <Option type="int" value="0" name="blendMode"/>
-          <Option type="Map" name="ddProperties">
-            <Option type="QString" value="" name="name"/>
-            <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString" />
+          <Option name="blendMode" value="0" type="int" />
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString" />
+            <Option name="properties" />
+            <Option name="type" value="collection" type="QString" />
           </Option>
-          <Option type="bool" value="false" name="drawToAllParts"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
-          <Option type="QString" value="&lt;symbol clip_to_extent=&quot;1&quot; type=&quot;line&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; pass=&quot;0&quot; locked=&quot;0&quot; id=&quot;{2ecad294-b530-4297-9e8c-4795535d7834}&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
-          <Option type="double" value="0" name="minLength"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
-          <Option type="QString" value="MM" name="minLengthUnit"/>
-          <Option type="double" value="0" name="offsetFromAnchor"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
-          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
-          <Option type="double" value="0" name="offsetFromLabel"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
-          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+          <Option name="drawToAllParts" value="false" type="bool" />
+          <Option name="enabled" value="1" type="QString" />
+          <Option name="labelAnchorPoint" value="centroid" type="QString" />
+          <Option name="lineSymbol" value="&lt;symbol frame_rate=&quot;10&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;line&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; id=&quot;{8cdd11df-b27b-4857-a53c-33d38400955f}&quot; pass=&quot;0&quot; class=&quot;ArrowLine&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;arrow_start_width&quot; value=&quot;4&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;arrow_start_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;arrow_start_width_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;arrow_type&quot; value=&quot;0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;arrow_width&quot; value=&quot;0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;arrow_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;arrow_width_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_length&quot; value=&quot;1.5&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_length_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_length_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_thickness&quot; value=&quot;0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_thickness_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_thickness_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;head_type&quot; value=&quot;0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;is_curved&quot; value=&quot;1&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;is_repeated&quot; value=&quot;1&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;offset_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/&gt;&lt;/Option&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;symbol frame_rate=&quot;10&quot; name=&quot;@symbol@0&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; type=&quot;fill&quot; alpha=&quot;1&quot; force_rhr=&quot;0&quot;&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;layer locked=&quot;0&quot; id=&quot;{029996ba-cce6-427d-9339-07d4440170fc}&quot; pass=&quot;0&quot; class=&quot;SimpleFill&quot; enabled=&quot;1&quot;&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;border_width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;color&quot; value=&quot;60,60,60,255&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;offset&quot; value=&quot;0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;outline_color&quot; value=&quot;60,60,60,255&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;outline_style&quot; value=&quot;no&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;outline_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;outline_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/&gt;&lt;/Option&gt;&lt;data_defined_properties&gt;&lt;Option type=&quot;Map&quot;&gt;&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/&gt;&lt;Option name=&quot;properties&quot;/&gt;&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/&gt;&lt;/Option&gt;&lt;/data_defined_properties&gt;&lt;/layer&gt;&lt;/symbol&gt;&lt;/layer&gt;&lt;/symbol&gt;" type="QString" />
+          <Option name="minLength" value="0" type="double" />
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString" />
+          <Option name="minLengthUnit" value="MM" type="QString" />
+          <Option name="offsetFromAnchor" value="0" type="double" />
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString" />
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString" />
+          <Option name="offsetFromLabel" value="0" type="double" />
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString" />
+          <Option name="offsetFromLabelUnit" value="MM" type="QString" />
         </Option>
       </callout>
     </settings>
   </labeling>
-</qgis>
+  </qgis>

--- a/threedi_schematisation_editor/user_layer_handlers.py
+++ b/threedi_schematisation_editor/user_layer_handlers.py
@@ -127,10 +127,9 @@ class UserLayerHandler:
         """Rollback changes for all layers with 1D group."""
         if self.MODEL not in self.layer_manager.common_editing_group:
             return
-        other_1d_handlers = self.other_linked_handlers
-        for layer_handler in other_1d_handlers:
+        for layer_handler in self.other_linked_handlers:
             layer_handler.disconnect_handler_signals()
-        for layer_handler in other_1d_handlers:
+        for layer_handler in self.other_linked_handlers:
             layer = layer_handler.layer
             if layer.isEditable():
                 if layer.isModified():
@@ -139,8 +138,10 @@ class UserLayerHandler:
                     answer = self.layer_manager.uc.ask(None, title, question)
                     if answer is True:
                         layer.commitChanges(stopEditing=True)
+                        layer_handler.decrease_nr_editable_layers()  # because signals are temporarily disconnected
                         continue
                 layer.rollBack()
+                layer_handler.decrease_nr_editable_layers()  # because signals are temporarily disconnected
         for layer_handler in self.other_linked_handlers:
             layer_handler.connect_handler_signals()
 

--- a/threedi_schematisation_editor/user_layer_handlers.py
+++ b/threedi_schematisation_editor/user_layer_handlers.py
@@ -190,6 +190,7 @@ class UserLayerHandler:
 
     def on_editing_started(self):
         """Action on editing started signal."""
+        self.multi_start_editing()
 
     def increase_nr_editable_layers(self):
         if isinstance(self.layer, QgsVectorLayer) and self.layer.isSpatial():

--- a/threedi_schematisation_editor/user_layer_handlers.py
+++ b/threedi_schematisation_editor/user_layer_handlers.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from functools import cached_property, partial
 from types import MappingProxyType
 
-from qgis.core import NULL, QgsExpression, QgsFeature, QgsFeatureRequest, QgsGeometry
+from qgis.core import NULL, QgsExpression, QgsFeature, QgsFeatureRequest, QgsGeometry, QgsVectorLayer
 from qgis.PyQt.QtCore import QTimer
 
 import threedi_schematisation_editor.data_models as dm
@@ -53,6 +53,7 @@ class UserLayerHandler:
     def connect_handler_signals(self):
         """Connecting layer signals."""
         self.layer.editingStarted.connect(self.on_editing_started)
+        self.layer.editingStopped.connect(self.on_editing_stopped)
         self.layer.beforeRollBack.connect(self.on_rollback)
         self.layer.beforeCommitChanges.connect(self.on_commit_changes)
         self.layer.featureAdded.connect(self.on_added_feature)
@@ -186,7 +187,14 @@ class UserLayerHandler:
 
     def on_editing_started(self):
         """Action on editing started signal."""
+        if isinstance(self.layer, QgsVectorLayer) and self.layer.isSpatial():
+            self.layer_manager.nr_editable_layers += 1
         self.multi_start_editing()
+
+    def on_editing_stopped(self):
+        """Action on editing started signal."""
+        if isinstance(self.layer, QgsVectorLayer) and self.layer.isSpatial():
+            self.layer_manager.nr_editable_layers -= 1
 
     def on_rollback(self):
         """Action on rollback signal."""

--- a/threedi_schematisation_editor/user_layer_handlers.py
+++ b/threedi_schematisation_editor/user_layer_handlers.py
@@ -53,7 +53,8 @@ class UserLayerHandler:
     def connect_handler_signals(self):
         """Connecting layer signals."""
         self.layer.editingStarted.connect(self.on_editing_started)
-        self.layer.editingStopped.connect(self.on_editing_stopped)
+        self.layer.editingStarted.connect(self.increase_nr_editable_layers)
+        self.layer.editingStopped.connect(self.decrease_nr_editable_layers)
         self.layer.beforeRollBack.connect(self.on_rollback)
         self.layer.beforeCommitChanges.connect(self.on_commit_changes)
         self.layer.featureAdded.connect(self.on_added_feature)
@@ -65,6 +66,8 @@ class UserLayerHandler:
     def disconnect_handler_signals(self):
         """Disconnecting layer signals."""
         self.layer.editingStarted.disconnect(self.on_editing_started)
+        self.layer.editingStarted.disconnect(self.increase_nr_editable_layers)
+        self.layer.editingStopped.disconnect(self.decrease_nr_editable_layers)
         self.layer.beforeRollBack.disconnect(self.on_rollback)
         self.layer.beforeCommitChanges.disconnect(self.on_commit_changes)
         self.layer.featureAdded.disconnect(self.on_added_feature)
@@ -187,12 +190,12 @@ class UserLayerHandler:
 
     def on_editing_started(self):
         """Action on editing started signal."""
+
+    def increase_nr_editable_layers(self):
         if isinstance(self.layer, QgsVectorLayer) and self.layer.isSpatial():
             self.layer_manager.nr_editable_layers += 1
-        self.multi_start_editing()
 
-    def on_editing_stopped(self):
-        """Action on editing started signal."""
+    def decrease_nr_editable_layers(self):
         if isinstance(self.layer, QgsVectorLayer) and self.layer.isSpatial():
             self.layer_manager.nr_editable_layers -= 1
 

--- a/threedi_schematisation_editor/user_layer_manager.py
+++ b/threedi_schematisation_editor/user_layer_manager.py
@@ -367,7 +367,6 @@ class LayersManager:
         """Initializing single model layer based on data model class."""
         default_style_name = "default"
         layer = gpkg_layer(self.model_gpkg_path, model_cls.__tablename__, model_cls.__layername__)
-        QgsExpressionContextUtils.setLayerVariable(layer, 'schematisation_uuid', self.uuid)
         layer_fields = layer.fields()
         fields_indexes = list(range(len(layer_fields)))
         form_ui_path = get_form_ui_path(model_cls.__tablename__)
@@ -430,6 +429,7 @@ class LayersManager:
         handler.connect_handler_signals()
         self.model_handlers[model_cls] = handler
         self.layer_handlers[layer.id()] = handler
+        QgsExpressionContextUtils.setLayerVariable(layer, 'schematisation_uuid', self.uuid)
 
     def load_vector_layers(self):
         """Loading all vector layers."""
@@ -440,7 +440,6 @@ class LayersManager:
             for model_cls in group_models:
                 msg = f"Loading {model_cls.__layername__} and its styles..."
                 self.uc.progress_bar(msg, 0, layer_count, i, clear_msg_bar=True)
-                QCoreApplication.processEvents()
                 self.initialize_data_model_layer(model_cls)
                 i += 1
 

--- a/threedi_schematisation_editor/user_layer_manager.py
+++ b/threedi_schematisation_editor/user_layer_manager.py
@@ -295,14 +295,14 @@ class LayersManager:
         return get_style_configurations()
 
     @property
-    def nr_editable_layers(self):
+    def nr_editable_layers(self) -> int:
         project_variable = ProjectVariableDict(name="nr_editable_layers")
         return project_variable[self.uuid]
 
     @nr_editable_layers.setter
-    def nr_editable_layers(self, value):
-        nr_editable_layers = ProjectVariableDict(name="nr_editable_layers")
-        nr_editable_layers[self.uuid] = value
+    def nr_editable_layers(self, value: int):
+        store = ProjectVariableDict(name="nr_editable_layers")
+        store[self.uuid] = value
 
     def setup_all_value_relation_widgets(self):
         """Setup all models value relation widgets."""
@@ -497,7 +497,6 @@ class LayersManager:
     def load_all_layers(self, from_project=False):
         """Creating/registering groups and loading/registering vector, raster and tabular layers."""
         self.register_custom_functions()
-        self.nr_editable_layers = 0
         if not from_project:
             self.create_groups()
             self.load_vector_layers()
@@ -507,6 +506,7 @@ class LayersManager:
             self.remove_loaded_layers(dry_remove=True)
             self.register_groups()
             self.register_vector_layers()
+        self.nr_editable_layers = 0
         self.setup_all_value_relation_widgets()
         self.iface.setActiveLayer(self.model_handlers[dm.ConnectionNode].layer)
 
@@ -523,6 +523,7 @@ class LayersManager:
         self.model_handlers.clear()
         self.layer_handlers.clear()
         self.spawned_groups.clear()
+        ProjectVariableDict(name="nr_editable_layers").pop(self.uuid, default=0)
 
     def add_joins(self):
         """Setting joins between layers."""

--- a/threedi_schematisation_editor/utils.py
+++ b/threedi_schematisation_editor/utils.py
@@ -98,6 +98,17 @@ class ProjectVariableDict:
     def __repr__(self):
         return f"{self.__class__.__name__}({self._load()})"
 
+    def pop(self, key, default=None):
+        data = self._load()
+        if key in data:
+            value = data.pop(key)
+            self._save(data)
+            return value
+        elif default is not None:
+            return default
+        else:
+            raise KeyError(key)
+
 
 def backup_schematisation_file(filename):
     """Make a backup of the schematisation file."""


### PR DESCRIPTION
- Change labelling expression to

	if (  map_get(from_json(@nr_editable_layers ), @schematisation_uuid) > 0, NULL,
		with_variable(
		'nr_intersections',
		array_length(overlay_equals(layer:=@layer, expression:= geom_to_wkt(@geometry))),
		if(@nr_intersections>0, @nr_intersections + 1, NULL)
		)
	)

When adding the schematisation to the project:
	- Generate a schematisation uuid
	- Set the nr_editable_layers for that schematisation to 0

- When adding vector layers with a geometry to the project, set the schematisation uuid as layer property
- Connect a method to editingStarted() signal to increase the nr_editable_layers with one
- Connect a method to editingStopped() signal to decrease the nr_editable_layers with one
- Removing schematisation from the project:
	- Pop this schematisation from the nr_editable_layers ProjectVariableDict 