### PR TITLE
Fix ID conflicts during structure import with edit channels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 
 - Display upgrade warnings (any UserWarning raised during upgrading)
 - Split BoundaryTypes in 1D and 2D types and add boundary types Discharge (total) and Groundwater discharge (total) to BoundaryType2D
+- Correctly set id's when importing orifices or weirs with edit channels option active
 
 
 2.1.4 (2025-04-18)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 
 - Display upgrade warnings (any UserWarning raised during upgrading)
 - Split BoundaryTypes in 1D and 2D types and add boundary types Discharge (total) and Groundwater discharge (total) to BoundaryType2D
-- Correctly set id's when importing orifices or weirs with edit channels option active
+- Correctly set id's when importing orifices or weirs with edit channels option active (#363)
 - Fix zooming to DEM extent when schematisation CRS differs from project CRS
 
 

--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -943,9 +943,11 @@ class StructuresIntegrator(LinearStructuresImporter):
         self.remove_hanging_cross_sections()
         # Process structures
         structures_to_add = []
-        for structure_id, structure_feat in enumerate(self.features_to_add[self.target_layer_name], start=1):
-            structure_feat["id"] = structure_id
+        next_feature_id = get_next_feature_id(self.target_layer)
+        for structure_feat in self.features_to_add[self.target_layer_name]:
+            structure_feat["id"] = next_feature_id
             structures_to_add.append(structure_feat)
+            next_feature_id += 1
         self.target_layer.startEditing()
         self.target_layer.addFeatures(structures_to_add)
         # Fallback import for disconnected structures.


### PR DESCRIPTION
This pull request fixes an issue where IDs for structures such as orifices and weirs were not being correctly assigned when importing with edit channels active. 
