### PR TITLE
Fix integrating objects when channel position and nodes don't match exactly

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix integrating objects in channels when connection node and channel start do not match exactly (#372)
 
 
 2.2.0 (2025-05-07)

--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -843,7 +843,7 @@ class StructuresIntegrator(LinearStructuresImporter):
         channel_geom = channel_feat.geometry()
         channel_polyline = channel_geom.asPolyline()
         first_point = channel_polyline[0]
-        first_node_id = self.node_by_location[first_point]
+        first_node_id = self.node_by_location.get(first_point, channel_attributes['connection_node_id_start'])
         first_node_feat = next(get_features_by_expression(self.node_layer, f'"id" = {first_node_id}'))
         node_field_names = self.layer_field_names_mapping[self.node_layer.name()]
         node_attributes = {field_name: first_node_feat[field_name] for field_name in node_field_names}


### PR DESCRIPTION
On adding objects to an existing channel use `connection_node_id_start` as fallback for finding the start node based on the channel position. The default way is still to find the node that is on the first point of the channel linestring and only when this is not the case the `connection_node_id_start` is used instead. @leendertvanwolfswinkel if you can think on any case where this is not the case; please let me know.