### PR TITLE
Fix handling of multi-point line geometries

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix integrating objects with line geometries that contain more than 2 points (#382)
 
 
 2.2.1 (2025-05-12)

--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -700,7 +700,9 @@ class StructuresIntegrator(LinearStructuresImporter):
             structure_geom = structure_feat.geometry()
             structure_geom_type = structure_geom.type()
             if structure_geom_type == QgsWkbTypes.GeometryType.LineGeometry:
-                start_point, end_point = structure_geom.asPolyline()
+                poly_line = structure_geom.asPolyline()
+                start_point = poly_line[0]
+                end_point = poly_line[-1]
                 start_geom, end_geom = QgsGeometry.fromPointXY(start_point), QgsGeometry.fromPointXY(end_point)
                 start_buffer = start_geom.buffer(
                     self.conversion_settings.snapping_distance, self.DEFAULT_INTERSECTION_BUFFER_SEGMENTS


### PR DESCRIPTION
Fix integrating objects with a line geometry that contains more than 2 points. In such a case the start and end point of the geometry are used to create a line geometry for the object