### PR TITLE
Fix crash when accessing `current_cross_section_location`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug that showed error on loading channel attribute table (#379)
 
 
 2.2.1 (2025-05-12)

--- a/threedi_schematisation_editor/forms/custom_forms.py
+++ b/threedi_schematisation_editor/forms/custom_forms.py
@@ -1156,7 +1156,9 @@ class AbstractFormWithXSTable(AbstractBaseForm):
             if cell_changed_signal is not None and cell_changed_slot is not None:
                 disconnect_signal(cell_changed_signal, cell_changed_slot)
         leading_table_name = "cross_section_table"
-        table = self.current_cross_section_location[leading_table_name] or ""
+        table = ""
+        if self.current_cross_section_location is not None:
+            table = self.current_cross_section_location[leading_table_name] or ""
         number_of_rows_main = len(table.split("\n"))
         for table_field_name, table_widget in self.cross_section_table_field_widget_map.items():
             if table_widget is None:


### PR DESCRIPTION
This pull request resolves an issue where attempting to access `current_cross_section_location` could result in a crash if its value was `None`. The logic has been updated to handle `None` values safely. Additionally, the `HISTORY.rst` file has been updated to document the fix.
