### PR TITLE
Fix mismatch value_map key types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 ------------------
 
 - Add processing algorithm to add NWRW parameters to surface parameters (#333)
+- Fix handling string keys in import with value_map (#279)
 
 
 2.2.2 (2025-05-20)

--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -219,7 +219,7 @@ class AbstractFeaturesImporter:
                     src_field_name = field_config[ColumnImportMethod.ATTRIBUTE.value]
                     src_value = source_feat[src_field_name]
                     value_map = field_config.get("value_map", {})
-                    field_value = value_map.get(src_value, src_value)
+                    field_value = value_map.get(str(src_value), src_value)
                     if field_value == NULL:
                         field_value = field_config.get("default_value", NULL)
                 elif method == ColumnImportMethod.EXPRESSION:

--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -219,6 +219,7 @@ class AbstractFeaturesImporter:
                     src_field_name = field_config[ColumnImportMethod.ATTRIBUTE.value]
                     src_value = source_feat[src_field_name]
                     value_map = field_config.get("value_map", {})
+                    # Prevent type mismatches in keys by casting keys to strings to match those the dict in src_value['value_map'] which is also forced to be strings
                     field_value = value_map.get(str(src_value), src_value)
                     if field_value == NULL:
                         field_value = field_config.get("default_value", NULL)

--- a/threedi_schematisation_editor/custom_widgets/__init__.py
+++ b/threedi_schematisation_editor/custom_widgets/__init__.py
@@ -297,7 +297,7 @@ class ImportFieldMappingUtils:
                 else widget.currentData()
             )
         elif column_idx == FeaturesImportConfig.VALUE_MAP_COLUMN_IDX:
-            key_value = widget.value_map
+            key_value = {str(key) : value for key, value in widget.value_map.items()}
             if not key_value:
                 return None
         elif column_idx == FeaturesImportConfig.EXPRESSION_COLUMN_IDX:


### PR DESCRIPTION
Enforces the use of strings as keys in lookups within the `value_map`. This change ensures consistent behavior and avoids potential issues caused by non-string keys. 
