### PR TITLE
Ensure `SOURCE_LAYER` is a `QgsVectorLayer` in processing algorithms.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ History
 - Processing algorithms 'Map surfaces/DWF to connection nodes' now use point on surface instead of centroid as start vertex of mapping line (#396)
 - Reset unspecified import settings on loading new import configuration (#286)
 - Fix handling string keys in import with value_map (#279)
+- Ensure source layer in conversion processing algorithms is a `QgsVectorLayer` (#404)
 
 
 2.2.2 (2025-05-20)

--- a/threedi_schematisation_editor/custom_tools/__init__.py
+++ b/threedi_schematisation_editor/custom_tools/__init__.py
@@ -985,7 +985,9 @@ class StructuresIntegrator(LinearStructuresImporter):
             next_structure_id = get_next_feature_id(self.target_layer)
             next_connection_node_id = get_next_feature_id(self.node_layer)
             locator = QgsPointLocator(self.node_layer, dst_crs, transform_ctx)
-            for disconnected_structure in self.external_source.getFeatures(disconnected_structure_ids):
+            for disconnected_structure in self.external_source.getFeatures():
+                if disconnected_structure.id() not in disconnected_structure_ids:
+                    continue
                 new_structure_feat, new_nodes, next_connection_node_id = self.process_structure_feature(
                     disconnected_structure,
                     structure_fields,

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -1,5 +1,8 @@
 # Copyright (C) 2025 by Lutra Consulting
+
+
 import json
+from abc import ABC, abstractmethod
 
 from qgis.core import (
     QgsProcessing,
@@ -23,7 +26,7 @@ from threedi_schematisation_editor.custom_tools import (
 )
 
 
-class BaseImporter(QgsProcessingAlgorithm):
+class BaseImporter(QgsProcessingAlgorithm, ABC):
     """Base class for all importers."""
 
     SOURCE_LAYER = "SOURCE_LAYER"
@@ -71,13 +74,15 @@ class BaseImporter(QgsProcessingAlgorithm):
         return {}
 
     # Abstract methods to be implemented by subclasses
+    @abstractmethod
     def get_feature_type(self):
         """Return the type of feature being imported."""
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def create_importer(self, source_layer, target_gpkg, import_config):
         """Create the appropriate importer instance."""
-        raise NotImplementedError
+        pass
 
     def processAlgorithm(self, parameters, context, feedback):
         source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -50,7 +50,7 @@ class BaseImporter(QgsProcessingAlgorithm):
         return self.tr(f"Import {self.get_feature_repr()}s")
 
     def shortHelpString(self):
-        return self.tr(f"""Import {get_feature_type()}s from the external source layer.""")
+        return self.tr(f"""Import {self.get_feature_repr()}s from the external source layer.""")
 
     def get_feature_repr(self):
         return self.FEATURE_TYPE.replace('_',' ')

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -74,7 +74,7 @@ class ImportConnectionNodes(QgsProcessingAlgorithm):
         self.addParameter(target_gpkg)
 
     def processAlgorithm(self, parameters, context, feedback):
-        source_layer = self.parameterAsSource(parameters, self.SOURCE_LAYER, context)
+        source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)
         if source_layer is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.SOURCE_LAYER))
         import_config_file = self.parameterAsFile(parameters, self.IMPORT_CONFIG, context)
@@ -147,7 +147,7 @@ class ImportCulverts(QgsProcessingAlgorithm):
         self.addParameter(target_gpkg)
 
     def processAlgorithm(self, parameters, context, feedback):
-        source_layer = self.parameterAsSource(parameters, self.SOURCE_LAYER, context)
+        source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)
         if source_layer is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.SOURCE_LAYER))
         import_config_file = self.parameterAsFile(parameters, self.IMPORT_CONFIG, context)
@@ -226,7 +226,7 @@ class ImportOrifices(QgsProcessingAlgorithm):
         self.addParameter(target_gpkg)
 
     def processAlgorithm(self, parameters, context, feedback):
-        source_layer = self.parameterAsSource(parameters, self.SOURCE_LAYER, context)
+        source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)
         if source_layer is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.SOURCE_LAYER))
         import_config_file = self.parameterAsFile(parameters, self.IMPORT_CONFIG, context)
@@ -305,7 +305,7 @@ class ImportWeirs(QgsProcessingAlgorithm):
         self.addParameter(target_gpkg)
 
     def processAlgorithm(self, parameters, context, feedback):
-        source_layer = self.parameterAsSource(parameters, self.SOURCE_LAYER, context)
+        source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)
         if source_layer is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.SOURCE_LAYER))
         import_config_file = self.parameterAsFile(parameters, self.IMPORT_CONFIG, context)
@@ -384,7 +384,7 @@ class ImportPipes(QgsProcessingAlgorithm):
         self.addParameter(target_gpkg)
 
     def processAlgorithm(self, parameters, context, feedback):
-        source_layer = self.parameterAsSource(parameters, self.SOURCE_LAYER, context)
+        source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)
         if source_layer is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.SOURCE_LAYER))
         import_config_file = self.parameterAsFile(parameters, self.IMPORT_CONFIG, context)

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -6,7 +6,7 @@ from qgis.core import (
     QgsProcessingAlgorithm,
     QgsProcessingException,
     QgsProcessingParameterFile,
-    QgsProcessingParameterVectorLayer,
+    QgsProcessingParameterFeatureSource,
     QgsProject,
 )
 from qgis.PyQt.QtCore import QCoreApplication
@@ -56,7 +56,7 @@ class BaseImporter(QgsProcessingAlgorithm):
         return self.FEATURE_TYPE
 
     def initAlgorithm(self, config=None):
-        source_layer = QgsProcessingParameterVectorLayer(
+        source_layer = QgsProcessingParameterFeatureSource(
             self.SOURCE_LAYER,
             self.tr(f"Source {self.get_feature_type()} layer"),
             self.get_source_layer_types(),

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -5,8 +5,8 @@ from qgis.core import (
     QgsProcessing,
     QgsProcessingAlgorithm,
     QgsProcessingException,
-    QgsProcessingParameterFeatureSource,
     QgsProcessingParameterFile,
+    QgsProcessingParameterVectorLayer,
     QgsProject,
 )
 from qgis.PyQt.QtCore import QCoreApplication
@@ -40,7 +40,7 @@ class BaseImporter(QgsProcessingAlgorithm):
         return "conversion"
 
     def initAlgorithm(self, config=None):
-        source_layer = QgsProcessingParameterFeatureSource(
+        source_layer = QgsProcessingParameterVectorLayer(
             self.SOURCE_LAYER,
             self.tr(f"Source {self.get_feature_type()} layer"),
             self.get_source_layer_types(),

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -91,7 +91,7 @@ class BaseImporter(QgsProcessingAlgorithm):
         raise NotImplementedError("Subclasses must implement create_importer()")
 
     def processAlgorithm(self, parameters, context, feedback):
-        source_layer = self.parameterAsVectorLayer(parameters, self.SOURCE_LAYER, context)
+        source_layer = self.parameterAsSource(parameters, self.SOURCE_LAYER, context)
         if source_layer is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.SOURCE_LAYER))
         import_config_file = self.parameterAsFile(parameters, self.IMPORT_CONFIG, context)

--- a/threedi_schematisation_editor/processing/algorithms_conversion.py
+++ b/threedi_schematisation_editor/processing/algorithms_conversion.py
@@ -29,7 +29,7 @@ class BaseImporter(QgsProcessingAlgorithm):
     SOURCE_LAYER = "SOURCE_LAYER"
     IMPORT_CONFIG = "IMPORT_CONFIG"
     TARGET_GPKG = "TARGET_GPKG"
-    FEATURE_TYPE = None  # To be overridden by subclasses
+    FEATURE_TYPE = ""  # To be overridden by subclasses
 
     def createInstance(self):
         return self.__class__()
@@ -47,24 +47,24 @@ class BaseImporter(QgsProcessingAlgorithm):
         return f"threedi_import_{self.FEATURE_TYPE}s"
 
     def displayName(self):
-        return self.tr(f"Import {self.FEATURE_TYPE.replace('_', ' ')}s")
+        return self.tr(f"Import {self.get_feature_repr()}s")
 
     def shortHelpString(self):
-        return self.tr(f"""Import {self.FEATURE_TYPE}s from the external source layer.""")
+        return self.tr(f"""Import {get_feature_type()}s from the external source layer.""")
 
-    def get_feature_type(self):
-        return self.FEATURE_TYPE
+    def get_feature_repr(self):
+        return self.FEATURE_TYPE.replace('_',' ')
 
     def initAlgorithm(self, config=None):
         source_layer = QgsProcessingParameterFeatureSource(
             self.SOURCE_LAYER,
-            self.tr(f"Source {self.get_feature_type()} layer"),
+            self.tr(f"Source {self.get_feature_repr()} layer"),
             self.get_source_layer_types(),
         )
         self.addParameter(source_layer)
         import_config_file = QgsProcessingParameterFile(
             self.IMPORT_CONFIG,
-            self.tr(f"{self.get_feature_type().title()} import configuration file"),
+            self.tr(f"{self.get_feature_repr().title()} import configuration file"),
             extension="json",
             behavior=QgsProcessingParameterFile.File,
         )


### PR DESCRIPTION
Replaced `parameterAsSource` with `parameterAsVectorLayer` in multiple algorithms to enforce the use of vector layers for `source_layer`. 

Having `source_layer` of type `QgsProcessingFeatureSource` caused issues in the `StructureIntegrator`. But this difference in type may cause other issues so I choose to fix this for all associated processing algorithms.

Also refactored the conversion processing algorithms to reduce duplicate code. This makes it easier to test the processing algorithm, e.g. importing weirs executes the same code as importing orifices.