### PR TITLE
Move cross_section_layer from LinearIntegrator to ChannelIntegrator

### DIFF
--- a/tests/test_vector_data_importer/test_importers.py
+++ b/tests/test_vector_data_importer/test_importers.py
@@ -240,22 +240,6 @@ class TestImporter:
         """Test that modifiable_layers returns the target and node layers when there is no integrator."""
         assert importer.modifiable_layers == [target_layer, node_layer]
 
-    def test_modifiable_layers_with_integrator(
-        self, importer, target_layer, node_layer
-    ):
-        """Test that modifiable_layers includes integrator layers when there is an integrator."""
-        # Create a mock integrator
-        integrator = MagicMock()
-        integrator.integrate_layer = MagicMock()
-        integrator.cross_section_layer = MagicMock()
-        importer.integrator = integrator
-        assert importer.modifiable_layers == [
-            target_layer,
-            node_layer,
-            integrator.integrate_layer,
-            integrator.cross_section_layer,
-        ]
-
     @patch(
         "threedi_schematisation_editor.vector_data_importer.importers.ChannelIntegrator.from_importer"
     )
@@ -305,8 +289,6 @@ class TestImporter:
         else:
             mock_channel_integrator_from_importer.assert_not_called()
         if make_pipe_integrator:
-            mock_pipe_integrator_from_importer.assert_called_once_with(
-                None, None, importer
-            )
+            mock_pipe_integrator_from_importer.assert_called_once_with(None, importer)
         else:
             mock_pipe_integrator_from_importer.assert_not_called()

--- a/threedi_schematisation_editor/vector_data_importer/importers.py
+++ b/threedi_schematisation_editor/vector_data_importer/importers.py
@@ -97,10 +97,7 @@ class Importer:
         """Return a list of the layers that can be modified."""
         layers = [self.target_layer, self.node_layer]
         if self.integrator:
-            layers += [
-                self.integrator.integrate_layer,
-                self.integrator.cross_section_layer,
-            ]
+            layers += self.integrator.modifiable_layers
         return layers
 
     def import_features(self, context=None, selected_ids=None):
@@ -172,7 +169,7 @@ class LinesImporter(Importer):
             dm.Weir,
             dm.Orifice,
         ]:
-            self.integrator = PipeIntegrator.from_importer(conduit_layer, None, self)
+            self.integrator = PipeIntegrator.from_importer(conduit_layer, self)
 
 
 class CulvertsImporter(LinesImporter):


### PR DESCRIPTION
Modification of layers is prevented in the tests by explecitly passing the layers to the importers and integrators. However, in the `LinearIntegrator` the `cross_section_layer` wat automatically retreived from the gpkg because it was automatically suplied as `None`. By moving the `cross_section_layer` (and related attributes) to the `ChannelIntegrator` that actually uses this layer, this issue is solved.
