### PR TITLE
Fix some geometry issues for the vector data importer

### DIFF
--- a/tests/test_vector_data_importer/test_integrators.py
+++ b/tests/test_vector_data_importer/test_integrators.py
@@ -286,7 +286,10 @@ class TestChannelStructureIntegration:
 
         # Call the method with the specified selected_ids
         result, processed_ids = LinearIntegrator.get_conduit_structures_data(
-            integrator, channel_feature, selected_ids=selected_ids
+            integrator,
+            channel_feature,
+            channel_feature.geometry(),
+            selected_ids=selected_ids,
         )
 
         # Check the results

--- a/tests/test_vector_data_importer/test_processors.py
+++ b/tests/test_vector_data_importer/test_processors.py
@@ -357,8 +357,18 @@ class TestLineProcessor:
 class TestUtilityFunctions:
     """Tests for utility functions in the processors module."""
 
-    def test_create_new_point_geometry(self, source_feature):
+    @pytest.mark.parametrize(
+        "geom",
+        [
+            QgsGeometry.fromPointXY(QgsPointXY(10, 20)),  # single part
+            QgsGeometry.fromMultiPointXY(
+                [QgsPointXY(10, 20), QgsPointXY(100, 200)]
+            ),  # multi part
+        ],
+    )
+    def test_create_new_point_geometry(self, source_feature, geom):
         """Test that create_new_point_geometry returns a point geometry."""
+        source_feature.setGeometry(geom)
         result = Processor.create_new_point_geometry(source_feature)
         assert isinstance(result, QgsGeometry)
         assert result.type() == QgsWkbTypes.PointGeometry

--- a/tests/test_vector_data_importer/test_processors.py
+++ b/tests/test_vector_data_importer/test_processors.py
@@ -45,7 +45,7 @@ def node_fields():
     return fields
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def source_feature():
     """Create a source feature with point geometry."""
     fields = QgsFields()
@@ -251,12 +251,6 @@ class TestLineProcessor:
         processor = LineProcessor(
             target_layer, dm.Pipe, node_layer, fields_configurations, {}
         )
-        # Mock function calls needed for process_feature
-        LineProcessor.new_geometry = MagicMock(
-            return_value=QgsGeometry.fromPolylineXY(
-                [QgsPointXY(10, 20), QgsPointXY(30, 40)]
-            )
-        )
         processor.update_connection_nodes = MagicMock(return_value=[])
         # Run process_feature and check results
         result = processor.process_feature(source_line_feature)
@@ -268,118 +262,96 @@ class TestLineProcessor:
         """Create a mock conversion settings object."""
         settings = MagicMock()
         settings.length_source_field = "length"
-        settings.length_fallback_value = 10.0
+        settings.length_fallback_value = 20.0
         settings.azimuth_source_field = "azimuth"
-        settings.azimuth_fallback_value = 90.0
+        settings.azimuth_fallback_value = 0.0
         return settings
 
     @pytest.mark.parametrize(
-        "model_class, expected_points",
+        "line",
         [
-            (dm.Pipe, [QgsPointXY(0, 0), QgsPointXY(5, 5), QgsPointXY(10, 10)]),
-            (dm.Culvert, [QgsPointXY(0, 0), QgsPointXY(5, 5), QgsPointXY(10, 10)]),
-            (dm.Weir, [QgsPointXY(0, 0), QgsPointXY(10, 10)]),
+            [[QgsPointXY(10, 20), QgsPointXY(10, 40)]],
+            [
+                [QgsPointXY(10, 20), QgsPointXY(10, 40)],
+                [QgsPointXY(100, 20), QgsPointXY(100, 40)],
+            ],
         ],
     )
-    def test_new_geometry_line(self, model_class, expected_points):
-        """Test new_geometry with line geometry for different model classes."""
-        # Create a mock feature with line geometry
-        feature = MagicMock()
-        feature.geometry.return_value.type.return_value = QgsWkbTypes.LineGeometry
-        feature.geometry.return_value.asPolyline.return_value = expected_points
-
-        # Create mock conversion settings
-        conversion_settings = MagicMock()
-
-        # Call the actual method (no need to mock it since we're testing its behavior)
-        with patch(
-            "threedi_schematisation_editor.vector_data_importer.processors.LineProcessor.new_geometry",
-            return_value=QgsGeometry.fromPolylineXY(expected_points),
-        ) as mock_new_geometry:
-            result = LineProcessor.new_geometry(
-                feature, conversion_settings, model_class
-            )
-
-            # Verify the mock was called with the correct arguments
-            mock_new_geometry.assert_called_once_with(
-                feature, conversion_settings, model_class
-            )
-
-            # Verify the result
-            assert result.type() == QgsWkbTypes.LineGeometry
-            assert result.asPolyline() == expected_points
-
-    def test_new_geometry_point_with_source_field(self):
-        """Test new_geometry with point geometry."""
-        # Create a mock feature with point geometry
-        feature = MagicMock()
-        feature.geometry.return_value.type.return_value = QgsWkbTypes.PointGeometry
-        feature.geometry.return_value.asPoint.return_value = QgsPointXY(10, 20)
-
-        # Configure feature for source fields if needed
-        field_values = {"length": 20.0, "azimuth": 45.0}
-        feature.__getitem__.side_effect = lambda key: field_values.get(key)
-
-        # Create conversion settings based on test case
-        conversion_settings = MagicMock()
-        conversion_settings.length_source_field = "length"
-        conversion_settings.azimuth_source_field = "azimuth"
-
-        # Expected geometry
-        expected_geometry = QgsGeometry.fromPolylineXY(
-            [QgsPointXY(10, 20), QgsPointXY(25, 35)]
+    def test_new_geometry_multi_geom_line(
+        self, source_feature, conversion_settings, line
+    ):
+        source_feature.setGeometry(QgsGeometry.fromMultiPolylineXY(line))
+        result = LineProcessor.new_geometry(
+            source_feature, conversion_settings, dm.Weir
         )
+        assert not result.isMultipart()
+        assert result.asPolyline() == [QgsPointXY(10, 20), QgsPointXY(10, 40)]
 
-        # Call the method
-        with patch(
-            "threedi_schematisation_editor.vector_data_importer.processors.LineProcessor.new_geometry",
-            return_value=expected_geometry,
-        ) as mock_new_geometry:
-            result = LineProcessor.new_geometry(feature, conversion_settings, dm.Pipe)
-
-            # Verify the mock was called with the correct arguments
-            mock_new_geometry.assert_called_once_with(
-                feature, conversion_settings, dm.Pipe
-            )
-
-            # Verify the result
-            assert result.type() == QgsWkbTypes.LineGeometry
-            assert result.asPolyline() == expected_geometry.asPolyline()
-
-    def test_new_geometry_point_with_fallback(self):
-        """Test new_geometry with point geometry."""
-        # Create a mock feature with point geometry
-        feature = MagicMock()
-        feature.geometry.return_value.type.return_value = QgsWkbTypes.PointGeometry
-        feature.geometry.return_value.asPoint.return_value = QgsPointXY(10, 20)
-
-        # Create conversion settings based on test case
-        conversion_settings = MagicMock()
-        conversion_settings.length_source_field = None
-        conversion_settings.length_fallback_value = 10.0
-        conversion_settings.azimuth_source_field = None
-        conversion_settings.azimuth_fallback_value = 90.0
-
-        # Expected geometry
-        expected_geometry = QgsGeometry.fromPolylineXY(
-            [QgsPointXY(10, 20), QgsPointXY(20, 20)]
+    @pytest.mark.parametrize(
+        "point", [[QgsPointXY(10, 20), QgsPointXY(100, 40)], [QgsPointXY(10, 20)]]
+    )
+    def test_new_geometry_multi_geom_point(
+        self, source_feature, conversion_settings, point
+    ):
+        source_feature.setGeometry(QgsGeometry.fromMultiPointXY(point))
+        result = LineProcessor.new_geometry(
+            source_feature, conversion_settings, dm.Weir
         )
+        assert not result.isMultipart()
+        assert result.asPolyline() == [QgsPointXY(10, 20), QgsPointXY(10, 40)]
 
-        # Call the method
-        with patch(
-            "threedi_schematisation_editor.vector_data_importer.processors.LineProcessor.new_geometry",
-            return_value=expected_geometry,
-        ) as mock_new_geometry:
-            result = LineProcessor.new_geometry(feature, conversion_settings, dm.Pipe)
+    @pytest.mark.parametrize("model_class", [dm.Pipe, dm.Culvert, dm.Channel])
+    def test_new_geometry_full_line(
+        self, source_feature, conversion_settings, model_class
+    ):
+        # Set geometry of source_feature
+        line = [QgsPointXY(0, 0), QgsPointXY(5, 5), QgsPointXY(10, 10)]
+        source_feature.setGeometry(QgsGeometry.fromPolylineXY(line))
+        # Retrieve geometry
+        result = LineProcessor.new_geometry(
+            source_feature, conversion_settings, model_class
+        )
+        # Verify that the full line is returned
+        assert result.asPolyline() == line
+        assert result.type() == QgsWkbTypes.LineGeometry
 
-            # Verify the mock was called with the correct arguments
-            mock_new_geometry.assert_called_once_with(
-                feature, conversion_settings, dm.Pipe
-            )
+    def test_new_geometry_simplified_line(self, source_feature, conversion_settings):
+        # Set geometry of source_feature
+        line = [QgsPointXY(0, 0), QgsPointXY(5, 5), QgsPointXY(10, 10)]
+        source_feature.setGeometry(QgsGeometry.fromPolylineXY(line))
+        # Retrieve geometry
+        result = LineProcessor.new_geometry(
+            source_feature, conversion_settings, dm.Weir
+        )
+        # Verify that only the start and end point are returned
+        assert result.asPolyline() == [line[0], line[-1]]
+        assert result.type() == QgsWkbTypes.LineGeometry
 
-            # Verify the result
-            assert result.type() == QgsWkbTypes.LineGeometry
-            assert result.asPolyline() == expected_geometry.asPolyline()
+    @pytest.mark.parametrize(
+        "feature_fields, expected_points",
+        [
+            ({}, [QgsPointXY(10, 20), QgsPointXY(10, 40)]),
+            (
+                {"length": 20.0, "azimuth": 90.0},
+                [QgsPointXY(10, 20), QgsPointXY(30, 20)],
+            ),
+        ],
+    )
+    def test_new_geometry_point(
+        self, conversion_settings, feature_fields, expected_points
+    ):
+        # Create feature with point geometry and specified fields
+        fields = QgsFields()
+        for field_name in feature_fields:
+            fields.append(QgsField(field_name, QVariant.Double))
+        feature = QgsFeature(fields)
+        feature.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(10, 20)))
+        for field_name, field_value in feature_fields.items():
+            feature.setAttribute(field_name, field_value)
+        # Retrieve geometry and verify results
+        result = LineProcessor.new_geometry(feature, conversion_settings, dm.Weir)
+        assert result.type() == QgsWkbTypes.LineGeometry
+        assert result.asPolyline() == expected_points
 
 
 class TestUtilityFunctions:

--- a/tests/test_vector_data_importer/test_utils.py
+++ b/tests/test_vector_data_importer/test_utils.py
@@ -219,3 +219,8 @@ def test_get_value_from_feature_with_field(value, expected_value):
 def test_get_value_from_feature_no_field(field):
     feat = {"foo": 1}
     assert get_float_value_from_feature(feat, "", 0) == 0
+
+
+def test_get_value_from_feature_field_not_present():
+    feat = {"bar": 1}
+    assert get_float_value_from_feature(feat, "foo", 0) == 0

--- a/tests/test_vector_data_importer/test_utils.py
+++ b/tests/test_vector_data_importer/test_utils.py
@@ -18,6 +18,7 @@ from threedi_schematisation_editor.vector_data_importer.utils import (
     ColumnImportMethod,
     FeatureManager,
     get_float_value_from_feature,
+    get_single_geometry,
     update_attributes,
 )
 
@@ -224,3 +225,20 @@ def test_get_value_from_feature_no_field(field):
 def test_get_value_from_feature_field_not_present():
     feat = {"bar": 1}
     assert get_float_value_from_feature(feat, "foo", 0) == 0
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        QgsGeometry.fromMultiPointXY([QgsPointXY(10, 20), QgsPointXY(100, 40)]),
+        QgsGeometry.fromPointXY(QgsPointXY(10, 20)),
+    ],
+)
+def test_get_single_geometry(geom):
+    fields = QgsFields()
+    fields.append(QgsField("id", QVariant.Int))
+    feature = QgsFeature(fields)
+    feature.setGeometry(geom)
+    single_geom = get_single_geometry(feature)
+    assert not single_geom.isMultipart()
+    assert single_geom.asPoint() == QgsPointXY(10, 20)

--- a/threedi_schematisation_editor/vector_data_importer/integrators.py
+++ b/threedi_schematisation_editor/vector_data_importer/integrators.py
@@ -474,40 +474,6 @@ class LinearIntegrator:
 
         return added_features
 
-    def integrate_features(self, input_feature_ids):
-        """Method responsible for the importing/integrating structures from the external feature source."""
-        all_processed_structure_ids = set()
-        features_to_add = defaultdict(list)
-        for conduit_feature in self.integrate_layer.getFeatures():
-            conduit_geom = get_src_geometry(conduit_feature)
-            if conduit_geom is None:
-                continue
-            conduit_structures, processed_structures_fids = (
-                self.get_conduit_structures_data(
-                    conduit_feature, conduit_geom, input_feature_ids
-                )
-            )
-            if not conduit_structures:
-                continue
-            added_features = self.integrate_structure_features(
-                conduit_feature, conduit_geom, conduit_structures
-            )
-            added_features[self.cross_section_layer.name()] = (
-                self.update_channel_cross_section_references(
-                    added_features[self.integrate_layer.name()], conduit_feature["id"]
-                )
-            )
-            for key in added_features:
-                features_to_add[key] += added_features[key]
-            all_processed_structure_ids |= processed_structures_fids
-        visited_channel_ids = [
-            channel["id"] for channel in features_to_add[self.integrate_layer.name()]
-        ]
-        self.cross_section_layer.deleteFeatures(
-            self.get_hanging_cross_sections(visited_channel_ids)
-        )
-        return features_to_add, list(all_processed_structure_ids)
-
 
 class PipeIntegrator(LinearIntegrator):
     def __init__(self, *args):

--- a/threedi_schematisation_editor/vector_data_importer/integrators.py
+++ b/threedi_schematisation_editor/vector_data_importer/integrators.py
@@ -17,6 +17,7 @@ from threedi_schematisation_editor.vector_data_importer.utils import (
     DEFAULT_INTERSECTION_BUFFER_SEGMENTS,
     FeatureManager,
     get_float_value_from_feature,
+    get_src_geometry,
     update_attributes,
 )
 from threedi_schematisation_editor.warnings import StructuresIntegratorWarning
@@ -192,7 +193,7 @@ class LinearIntegrator:
         processed_structure_ids = set()
         if selected_ids is None:
             selected_ids = set()
-        conduit_geometry = conduit_feat.geometry()
+        conduit_geometry = get_src_geometry(conduit_feat)
         structure_features_map, structure_index = self.spatial_indexes_map["source"]
         structure_fids = structure_index.intersects(conduit_geometry.boundingBox())
         for structure_fid in structure_fids:
@@ -415,7 +416,7 @@ class LinearIntegrator:
     def integrate_structure_features(self, conduit_feat, conduit_structures):
         """Integrate structures with a channel network."""
         added_features = defaultdict(list)
-        conduit_geom = conduit_feat.geometry()
+        conduit_geom = get_src_geometry(conduit_feat)
         total_length = sum(
             conduit_structure.length for conduit_structure in conduit_structures
         )

--- a/threedi_schematisation_editor/vector_data_importer/integrators.py
+++ b/threedi_schematisation_editor/vector_data_importer/integrators.py
@@ -187,13 +187,14 @@ class LinearIntegrator:
             conduit_feat["id"], structure_feat, intersection_m, structure_length
         )
 
-    def get_conduit_structures_data(self, conduit_feat, selected_ids=None):
+    def get_conduit_structures_data(
+        self, conduit_feat, conduit_geometry, selected_ids=None
+    ):
         """Extract and calculate channel structures data."""
         conduit_structures = []
         processed_structure_ids = set()
         if selected_ids is None:
             selected_ids = set()
-        conduit_geometry = get_src_geometry(conduit_feat)
         structure_features_map, structure_index = self.spatial_indexes_map["source"]
         structure_fids = structure_index.intersects(conduit_geometry.boundingBox())
         for structure_fid in structure_fids:
@@ -413,10 +414,11 @@ class LinearIntegrator:
             added_conduits.append(substring_feat)
         return added_conduits
 
-    def integrate_structure_features(self, conduit_feat, conduit_structures):
+    def integrate_structure_features(
+        self, conduit_feat, conduit_geom, conduit_structures
+    ):
         """Integrate structures with a channel network."""
         added_features = defaultdict(list)
-        conduit_geom = get_src_geometry(conduit_feat)
         total_length = sum(
             conduit_structure.length for conduit_structure in conduit_structures
         )
@@ -477,13 +479,18 @@ class LinearIntegrator:
         all_processed_structure_ids = set()
         features_to_add = defaultdict(list)
         for conduit_feature in self.integrate_layer.getFeatures():
+            conduit_geom = get_src_geometry(conduit_feature)
+            if conduit_geom is None:
+                continue
             conduit_structures, processed_structures_fids = (
-                self.get_conduit_structures_data(conduit_feature, input_feature_ids)
+                self.get_conduit_structures_data(
+                    conduit_feature, conduit_geom, input_feature_ids
+                )
             )
             if not conduit_structures:
                 continue
             added_features = self.integrate_structure_features(
-                conduit_feature, conduit_structures
+                conduit_feature, conduit_geom, conduit_structures
             )
             added_features[self.cross_section_layer.name()] = (
                 self.update_channel_cross_section_references(
@@ -526,13 +533,18 @@ class PipeIntegrator(LinearIntegrator):
         all_processed_structure_ids = set()
         features_to_add = defaultdict(list)
         for conduit_feature in self.integrate_layer.getFeatures():
+            conduit_geom = get_src_geometry(conduit_feature)
+            if conduit_geom is None:
+                continue
             conduit_structures, processed_structures_fids = (
-                self.get_conduit_structures_data(conduit_feature, input_feature_ids)
+                self.get_conduit_structures_data(
+                    conduit_feature, conduit_geom, input_feature_ids
+                )
             )
             if not conduit_structures:
                 continue
             added_features = self.integrate_structure_features(
-                conduit_feature, conduit_structures
+                conduit_feature, conduit_geom, conduit_structures
             )
             for key in added_features:
                 features_to_add[key] += added_features[key]
@@ -608,13 +620,18 @@ class ChannelIntegrator(LinearIntegrator):
         all_processed_structure_ids = set()
         features_to_add = defaultdict(list)
         for conduit_feature in self.integrate_layer.getFeatures():
+            conduit_geom = get_src_geometry(conduit_feature)
+            if conduit_geom is None:
+                continue
             conduit_structures, processed_structures_fids = (
-                self.get_conduit_structures_data(conduit_feature, input_feature_ids)
+                self.get_conduit_structures_data(
+                    conduit_feature, conduit_geom, input_feature_ids
+                )
             )
             if not conduit_structures:
                 continue
             added_features = self.integrate_structure_features(
-                conduit_feature, conduit_structures
+                conduit_feature, conduit_geom, conduit_structures
             )
             added_features[self.cross_section_layer.name()] = (
                 self.update_channel_cross_section_references(

--- a/threedi_schematisation_editor/vector_data_importer/processors.py
+++ b/threedi_schematisation_editor/vector_data_importer/processors.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC
 from functools import cached_property
 
@@ -47,10 +48,9 @@ class Processor(ABC):
             return False
 
     @classmethod
-    def create_new_point_geometry(cls, src_feat):
+    def create_new_point_geometry(cls, src_geom):
         """Create a new point feature geometry based on the source feature."""
-        src_geometry = get_src_geometry(src_feat)
-        src_point = src_geometry.asPoint()
+        src_point = src_geom.asPoint()
         dst_point = src_point
         dst_geometry = QgsGeometry.fromPointXY(dst_point)
         return dst_geometry
@@ -201,8 +201,15 @@ class CrossSectionLocationProcessor(Processor):
             raise NotImplementedError(f"Unsupported geometry type: '{geometry_type}'")
 
     def process_feature(self, src_feat):
-        src_geom = QgsGeometry(src_feat.geometry())
-        if self.transformation:
+        src_geom = get_src_geometry(src_feat, none_ok=True)
+        if src_geom is None:
+            # Cross section locations without geometries are valid, so only break when the geometry cannot be processed
+            if src_feat.geometry():
+                return {}
+            # make sure src_geom is a geometry
+            else:
+                src_geom = QgsGeometry()
+        if self.transformation and src_geom:
             src_geom.transform(self.transformation)
         channel_id = self.get_matching_channel(src_feat, src_geom)
         ref_channel = next(
@@ -240,7 +247,10 @@ class ConnectionNodeProcessor(Processor):
 
     def process_feature(self, src_feat):
         """Process source point into connection node feature."""
-        new_geom = ConnectionNodeProcessor.create_new_point_geometry(src_feat)
+        src_geom = get_src_geometry(src_feat)
+        if src_geom is None:
+            return {}
+        new_geom = ConnectionNodeProcessor.create_new_point_geometry(src_geom)
         if self.transformation:
             new_geom.transform(self.transformation)
         new_feat = self.target_manager.create_new(new_geom, self.target_fields)
@@ -303,7 +313,10 @@ class PointProcessor(StructureProcessor):
     def process_feature(self, src_feat):
         """Process source point structure feature."""
         new_nodes = []
-        new_geom = PointProcessor.create_new_point_geometry(src_feat)
+        src_geom = get_src_geometry(src_feat)
+        if src_geom is None:
+            return {}
+        new_geom = PointProcessor.create_new_point_geometry(src_geom)
         if self.transformation:
             new_geom.transform(self.transformation)
         new_feat = self.target_manager.create_new(new_geom, self.target_fields)
@@ -325,12 +338,11 @@ class PointProcessor(StructureProcessor):
 
 class LineProcessor(StructureProcessor):
     @staticmethod
-    def new_geometry(src_feat, conversion_settings, target_model_cls):
+    def new_geometry(src_feat, src_geom, conversion_settings, target_model_cls):
         """Create new structure geometry based on the source structure feature."""
-        src_geometry = get_src_geometry(src_feat)
-        geometry_type = src_geometry.type()
+        geometry_type = src_geom.type()
         if geometry_type == QgsWkbTypes.GeometryType.LineGeometry:
-            src_polyline = src_geometry.asPolyline()
+            src_polyline = src_geom.asPolyline()
             dst_polyline = (
                 src_polyline
                 if target_model_cls in [dm.Culvert, dm.Pipe, dm.Channel]
@@ -338,7 +350,7 @@ class LineProcessor(StructureProcessor):
             )
             dst_geometry = QgsGeometry.fromPolylineXY(dst_polyline)
         elif geometry_type == QgsWkbTypes.GeometryType.PointGeometry:
-            start_point = src_geometry.asPoint()
+            start_point = src_geom.asPoint()
             length = get_float_value_from_feature(
                 src_feat,
                 conversion_settings.length_source_field,
@@ -376,8 +388,11 @@ class LineProcessor(StructureProcessor):
 
     def process_feature(self, src_feat):
         """Process source linear structure feature."""
+        src_geom = get_src_geometry(src_feat)
+        if src_geom is None:
+            return {}
         new_geom = LineProcessor.new_geometry(
-            src_feat, self.conversion_settings, self.target_model_cls
+            src_feat, src_geom, self.conversion_settings, self.target_model_cls
         )
         if self.transformation:
             new_geom.transform(self.transformation)

--- a/threedi_schematisation_editor/vector_data_importer/processors.py
+++ b/threedi_schematisation_editor/vector_data_importer/processors.py
@@ -20,6 +20,7 @@ from threedi_schematisation_editor.vector_data_importer.utils import (
     ColumnImportMethod,
     FeatureManager,
     get_float_value_from_feature,
+    get_single_geometry,
     update_attributes,
 )
 
@@ -48,9 +49,7 @@ class Processor(ABC):
     @classmethod
     def create_new_point_geometry(cls, src_feat):
         """Create a new point feature geometry based on the source feature."""
-        src_geometry = QgsGeometry(src_feat.geometry())
-        if src_geometry.isMultipart():
-            src_geometry.convertToSingleType()
+        src_geometry = get_single_geometry(src_feat)
         src_point = src_geometry.asPoint()
         dst_point = src_point
         dst_geometry = QgsGeometry.fromPointXY(dst_point)
@@ -328,9 +327,7 @@ class LineProcessor(StructureProcessor):
     @staticmethod
     def new_geometry(src_feat, conversion_settings, target_model_cls):
         """Create new structure geometry based on the source structure feature."""
-        src_geometry = QgsGeometry(src_feat.geometry())
-        if src_geometry.isMultipart():
-            src_geometry.convertToSingleType()
+        src_geometry = get_single_geometry(src_feat)
         geometry_type = src_geometry.type()
         if geometry_type == QgsWkbTypes.GeometryType.LineGeometry:
             src_polyline = src_geometry.asPolyline()

--- a/threedi_schematisation_editor/vector_data_importer/processors.py
+++ b/threedi_schematisation_editor/vector_data_importer/processors.py
@@ -20,7 +20,7 @@ from threedi_schematisation_editor.vector_data_importer.utils import (
     ColumnImportMethod,
     FeatureManager,
     get_float_value_from_feature,
-    get_single_geometry,
+    get_src_geometry,
     update_attributes,
 )
 
@@ -49,7 +49,7 @@ class Processor(ABC):
     @classmethod
     def create_new_point_geometry(cls, src_feat):
         """Create a new point feature geometry based on the source feature."""
-        src_geometry = get_single_geometry(src_feat)
+        src_geometry = get_src_geometry(src_feat)
         src_point = src_geometry.asPoint()
         dst_point = src_point
         dst_geometry = QgsGeometry.fromPointXY(dst_point)
@@ -327,7 +327,7 @@ class LineProcessor(StructureProcessor):
     @staticmethod
     def new_geometry(src_feat, conversion_settings, target_model_cls):
         """Create new structure geometry based on the source structure feature."""
-        src_geometry = get_single_geometry(src_feat)
+        src_geometry = get_src_geometry(src_feat)
         geometry_type = src_geometry.type()
         if geometry_type == QgsWkbTypes.GeometryType.LineGeometry:
             src_polyline = src_geometry.asPolyline()

--- a/threedi_schematisation_editor/vector_data_importer/utils.py
+++ b/threedi_schematisation_editor/vector_data_importer/utils.py
@@ -55,13 +55,17 @@ def update_attributes(fields_config, model_cls, source_feat, *new_features):
 
 
 def get_float_value_from_feature(feature, field_name, fallback_value):
-    value = fallback_value
-    if field_name and feature[field_name] != NULL:
+    if field_name:
         try:
-            value = convert_to_type(feature[field_name], float)
-        except TypeConversionError:
-            pass
-    return value
+            feature[field_name]
+        except KeyError:
+            return fallback_value
+        if feature[field_name] != NULL:
+            try:
+                return convert_to_type(feature[field_name], float)
+            except TypeConversionError:
+                return fallback_value
+    return fallback_value
 
 
 class FeatureManager:

--- a/threedi_schematisation_editor/vector_data_importer/utils.py
+++ b/threedi_schematisation_editor/vector_data_importer/utils.py
@@ -125,3 +125,10 @@ class ColumnImportMethod(Enum):
 
     def __str__(self):
         return self.name.capitalize()
+
+
+def get_single_geometry(feature: QgsFeature) -> QgsGeometry:
+    geom = feature.geometry()
+    if feature.geometry().isMultipart():
+        geom.convertToSingleType()
+    return geom

--- a/threedi_schematisation_editor/vector_data_importer/utils.py
+++ b/threedi_schematisation_editor/vector_data_importer/utils.py
@@ -12,7 +12,10 @@ from qgis.core import (
 )
 
 from threedi_schematisation_editor.utils import TypeConversionError, convert_to_type
-from threedi_schematisation_editor.warnings import FeaturesImporterWarning
+from threedi_schematisation_editor.warnings import (
+    FeaturesImporterWarning,
+    GeometryImporterWarning,
+)
 
 DEFAULT_INTERSECTION_BUFFER = 1
 DEFAULT_INTERSECTION_BUFFER_SEGMENTS = 5
@@ -129,10 +132,34 @@ class ColumnImportMethod(Enum):
         return self.name.capitalize()
 
 
-def get_src_geometry(feature: QgsFeature) -> QgsGeometry:
+def get_src_geometry(feature: QgsFeature, none_ok=False) -> QgsGeometry:
+    # convert source geometry to type that can be processed
+    # when the geometry cannot be handled None is returned and warnings/errors are raised upstream
+    warning_base = f"Source geometry of feature with id {feature.id()}"
     geom = feature.geometry()
+    if geom is None:
+        if not none_ok:
+            warnings.warn(f"{warning_base} is None", GeometryImporterWarning)
+        return None
+    if geom.type() not in [
+        QgsWkbTypes.GeometryType.Point,
+        QgsWkbTypes.GeometryType.Line,
+        QgsWkbTypes.GeometryType.Polygon,
+    ]:
+        warnings.warn(
+            f"{warning_base} has unsupported geometry type", GeometryImporterWarning
+        )
+        return None
     # the desired geometry type is linear (not curved), single (not multi-part) and flat (no z- or m-coordinates) and
-    desired_type = QgsWkbTypes.linearType(QgsWkbTypes.singleType(QgsWkbTypes.flatType(geom.wkbType())))
+    desired_type = QgsWkbTypes.linearType(
+        QgsWkbTypes.singleType(QgsWkbTypes.flatType(geom.wkbType()))
+    )
     # convert the source geometry to the desired type
-    return geom.coerceToType(desired_type)[0]
-
+    try:
+        return geom.coerceToType(desired_type)[0]
+    except Exception:
+        warnings.warn(
+            f"{warning_base} cannot be converted to desired geometry type",
+            GeometryImporterWarning,
+        )
+        return None

--- a/threedi_schematisation_editor/warnings.py
+++ b/threedi_schematisation_editor/warnings.py
@@ -14,3 +14,9 @@ class FeaturesImporterWarning(ThreediSchematisationEditorWarning):
     """
     Custom warning to indicate issues related to the Structures Integrator.
     """
+
+
+class GeometryImporterWarning(ThreediSchematisationEditorWarning):
+    """
+    Custom warning to indicate issues related imported geometries
+    """


### PR DESCRIPTION
Add function `get_src_geometry` to utils that ensures that:
* source geometry is Point, Line or Polygon
* source geometry is flat, single part and linear
* source geometry is not None (optional)
In case any of these conditions cannot be met, a warning is raised.

`get_src_geometry` is used on the top level of iterations over features and the retrieved geometry is passed downstream. When no geometry can be retrieved, the data is skipped except for the cross section location importer becaue that importer is designed to handle data without geometry as well.