### PR TITLE
Add validation for VDI configuration handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ADD https://raw.githubusercontent.com/nens/nens-dependency-loader/refs/heads/mai
 RUN python3 /root/dependencies.py
 
 RUN pip3 install -r /root/requirements-test.txt -c /root/constraints.txt --no-deps --upgrade --target /usr/share/qgis/python/plugins
+# TODO: move dependency to dependency loader!!!!
+RUN pip3 install pydantic
 
 # Note: we'll mount the current dir into this WORKDIR
 WORKDIR /root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/threedi_schematisation_editor

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ History
 - Add option to integrate weirs and orifices on pipes (#246)
 - Add importer for cross section data (#253)
 - Fix crashes during project load (#437)
+- Add support for validation of configuration files for vector data importing (#441)
 
 
 2.3.4 (2025-10-01)

--- a/tests/test_vector_data_importer/data/config/import_weirs_fix.json
+++ b/tests/test_vector_data_importer/data/config/import_weirs_fix.json
@@ -136,8 +136,8 @@
       "source_attribute": ""
     },
     "exchange_level": {
-      "method": "default",
-      "source_attribute": ""
+      "method": "source_attribute",
+      "source_attribute": "bank_level"
     },
     "exchange_type": {
       "method": "default",

--- a/tests/test_vector_data_importer/test_cross_section_location_processor.py
+++ b/tests/test_vector_data_importer/test_cross_section_location_processor.py
@@ -15,7 +15,9 @@ from shapely.testing import assert_geometries_equal
 from threedi_schematisation_editor.vector_data_importer.processors import (
     CrossSectionLocationProcessor,
 )
-from threedi_schematisation_editor.vector_data_importer.utils import ConversionSettings
+from threedi_schematisation_editor.vector_data_importer.settings_model import (
+    ConversionSettings,
+)
 
 
 @pytest.fixture(scope="function")
@@ -53,7 +55,7 @@ def processor(channels, target_layer, import_config):
         target_layer=target_layer,
         target_model_cls=None,
         channel_layer=channels,
-        conversion_settings=ConversionSettings(import_config["conversion_settings"]),
+        conversion_settings=ConversionSettings(**import_config["conversion_settings"]),
         target_fields_config=None,
     )
 
@@ -242,16 +244,17 @@ def test_get_new_geom_no_geometry(processor, ref_channel_id, expected_geom):
     "method, column", [("source_attribute", "id"), ("expression", "code")]
 )
 def test_channel_mapping(channels, target_layer, import_config, method, column):
-    conversion_settings = {
+    conversion_config = {
         "join_field_tgt": {"method": method, method: column},
         "snapping_distance": 6,
         "use_snapping": True,
     }
+    conversion_settings = ConversionSettings(**conversion_config)
     processor = CrossSectionLocationProcessor(
         target_layer=target_layer,
         target_model_cls=None,
         channel_layer=channels,
-        conversion_settings=ConversionSettings(conversion_settings),
+        conversion_settings=conversion_settings,
         target_fields_config=None,
     )
     channel_id_map = {feat[column]: feat for feat in channels.getFeatures()}
@@ -275,7 +278,7 @@ def test_channel_mapping_empty_join_values(
         target_layer=target_layer,
         target_model_cls=None,
         channel_layer=channels,
-        conversion_settings=ConversionSettings(conversion_settings),
+        conversion_settings=ConversionSettings(**conversion_settings),
         target_fields_config=None,
     )
     assert processor.channel_mapping == {}
@@ -294,7 +297,7 @@ def test_get_join_feat_src_value(channels, target_layer, import_config, method, 
         target_layer=target_layer,
         target_model_cls=None,
         channel_layer=channels,
-        conversion_settings=ConversionSettings(conversion_settings),
+        conversion_settings=ConversionSettings(**conversion_settings),
         target_fields_config=None,
     )
     feat = channels.getFeature(1)
@@ -322,7 +325,7 @@ def test_get_join_feat_src_value_invalid(
         target_layer=target_layer,
         target_model_cls=None,
         channel_layer=channels,
-        conversion_settings=ConversionSettings(conversion_settings),
+        conversion_settings=ConversionSettings(**conversion_settings),
         target_fields_config=None,
     )
     assert processor.get_join_feat_src_value(channels.getFeature(1)) is None

--- a/tests/test_vector_data_importer/test_processors_cross_section_data.py
+++ b/tests/test_vector_data_importer/test_processors_cross_section_data.py
@@ -21,9 +21,11 @@ import threedi_schematisation_editor.data_models as dm
 from threedi_schematisation_editor.vector_data_importer.processors import (
     CrossSectionDataProcessor,
 )
+from threedi_schematisation_editor.vector_data_importer.settings_model import (
+    ConversionSettings,
+)
 from threedi_schematisation_editor.vector_data_importer.utils import (
     ColumnImportMethod,
-    ConversionSettings,
 )
 from threedi_schematisation_editor.warnings import ProcessorWarning
 
@@ -425,7 +427,7 @@ def test_find_target_object_no_match(
 @pytest.fixture
 def conversion_settings():
     return ConversionSettings(
-        {
+        **{
             "set_lowest_point_to_zero": False,
             "use_lowest_point_as_reference": True,
         }
@@ -612,7 +614,7 @@ def test_get_feat_from_group_use_lowest_as_ref(
     use_lowest_point_as_reference,
 ):
     conversion_settings = ConversionSettings(
-        {"use_lowest_point_as_reference": use_lowest_point_as_reference}
+        **{"use_lowest_point_as_reference": use_lowest_point_as_reference}
     )
     target_model_cls = dm.CrossSectionLocation
     layer = make_layer(target_model_cls.__tablename__)

--- a/tests/test_vector_data_importer/test_settings_model.py
+++ b/tests/test_vector_data_importer/test_settings_model.py
@@ -4,35 +4,39 @@ import pytest
 
 from threedi_schematisation_editor.vector_data_importer.settings_model import (
     FieldMapConfig,
+    FieldMapConfigDefaultValueMissingError,
+    FieldMapConfigExpressionMissingError,
+    FieldMapConfigMethodMissingError,
+    FieldMapConfigSourceAttributeMissingError,
     FieldsSectionValidator,
 )
 
 
 @pytest.mark.parametrize(
-    "config_dict,valid",
+    "config_dict,expected_error",
     [
-        ({"method": "auto", "source_attribute": "foo"}, True),
-        ({"method": "ignore"}, True),
-        ({"method": "source_attribute"}, False),
-        ({"method": "source_attribute", "source_attribute": "foo"}, True),
+        ({"method": "auto", "source_attribute": "foo"}, None),
+        ({"method": "ignore"}, None),
+        ({"method": "source_attribute"}, FieldMapConfigSourceAttributeMissingError),
+        ({"method": "source_attribute", "source_attribute": "foo"}, None),
         (
             {
                 "method": "source_attribute",
                 "source_attribute": "foo",
                 "default_value": "bar",
             },
-            True,
+            None,
         ),
-        ({"method": "expression"}, False),
-        ({"method": "expression", "expression": "foo"}, True),
-        ({"method": "expression", "expression": "foo", "default_value": "bar"}, True),
-        ({"method": "default"}, False),
-        ({"method": "default", "default_value": "foo"}, True),
-        ({}, False),
+        ({"method": "expression"}, FieldMapConfigExpressionMissingError),
+        ({"method": "expression", "expression": "foo"}, None),
+        ({"method": "expression", "expression": "foo", "default_value": "bar"}, None),
+        ({"method": "default"}, FieldMapConfigDefaultValueMissingError),
+        ({"method": "default", "default_value": "foo"}, None),
+        ({}, FieldMapConfigMethodMissingError),
     ],
 )
-def test_field_map_config(config_dict, valid):
-    if valid:
+def test_field_map_config(config_dict, expected_error):
+    if not expected_error:
         assert FieldMapConfig(**config_dict)
     else:
         with pytest.raises(ValueError):

--- a/tests/test_vector_data_importer/test_settings_model.py
+++ b/tests/test_vector_data_importer/test_settings_model.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+import pytest
+
+from threedi_schematisation_editor.vector_data_importer.settings_model import (
+    FieldMapConfig,
+    FieldsSectionValidator,
+)
+
+
+@pytest.mark.parametrize(
+    "config_dict,valid",
+    [
+        ({"method": "auto", "source_attribute": "foo"}, True),
+        ({"method": "ignore"}, True),
+        ({"method": "source_attribute"}, False),
+        ({"method": "source_attribute", "source_attribute": "foo"}, True),
+        (
+            {
+                "method": "source_attribute",
+                "source_attribute": "foo",
+                "default_value": "bar",
+            },
+            True,
+        ),
+        ({"method": "expression"}, False),
+        ({"method": "expression", "expression": "foo"}, True),
+        ({"method": "expression", "expression": "foo", "default_value": "bar"}, True),
+        ({"method": "default"}, False),
+        ({"method": "default", "default_value": "foo"}, True),
+        ({}, False),
+    ],
+)
+def test_field_map_config(config_dict, valid):
+    if valid:
+        assert FieldMapConfig(**config_dict)
+    else:
+        with pytest.raises(ValueError):
+            FieldMapConfig(**config_dict)
+
+
+@dataclass
+class Test:
+    foo: int
+    bar: str
+
+
+@pytest.mark.parametrize(
+    "config_dict,valid,expected_keys",
+    [
+        (
+            {
+                "foo": {"method": "auto"},
+                "bar": {"method": "source_attribute", "source_attribute": "baz"},
+            },
+            True,
+            ["foo", "bar"],
+        ),
+        ({"foo": {"this": "that"}}, False, []),
+        ({"fooo": {"this": "that"}}, True, []),
+        ({"foo": {"method": "auto"}}, True, ["foo"]),
+    ],
+)
+def test_field_map_config_validator(config_dict, valid, expected_keys):
+    validator = FieldsSectionValidator(Test)
+    if valid:
+        valid_config = validator.validate(**config_dict)
+        assert sorted(valid_config.keys()) == sorted(expected_keys)
+        for value in valid_config.values():
+            assert isinstance(value, FieldMapConfig)
+    else:
+        with pytest.raises(ValueError):
+            validator.validate(**config_dict)

--- a/tests/test_vector_data_importer/test_utils.py
+++ b/tests/test_vector_data_importer/test_utils.py
@@ -23,7 +23,6 @@ from shapely.testing import assert_geometries_equal
 
 from threedi_schematisation_editor.vector_data_importer.utils import (
     ColumnImportMethod,
-    ConversionSettings,
     FeatureManager,
     get_field_config_value,
     get_float_value_from_feature,

--- a/threedi_schematisation_editor/vector_data_importer/importers.py
+++ b/threedi_schematisation_editor/vector_data_importer/importers.py
@@ -22,6 +22,9 @@ from threedi_schematisation_editor.vector_data_importer.processors import (
     CrossSectionLocationProcessor,
     LineProcessor,
 )
+from threedi_schematisation_editor.vector_data_importer.settings_model import (
+    get_field_map_config,
+)
 from threedi_schematisation_editor.vector_data_importer.utils import ConversionSettings
 
 
@@ -34,6 +37,7 @@ class Importer:
 
     @cached_property
     def conversion_settings(self):
+        # TODO: refactor
         conversion_config = self.import_settings.get("conversion_settings", {})
         return ConversionSettings(conversion_config)
 
@@ -144,11 +148,14 @@ class SpatialImporter(Importer):
             else node_layer
         )
         self.fields_configurations = {
-            target_model_cls: self.import_settings.get("fields", {}),
+            target_model_cls: get_field_map_config(
+                self.import_settings.get("fields", {}), target_model_cls
+            )
         }
         if target_model_cls != dm.ConnectionNode:
-            self.fields_configurations[dm.ConnectionNode] = self.import_settings.get(
-                "connection_node_fields", {}
+            self.fields_configurations[dm.ConnectionNode] = get_field_map_config(
+                import_settings.get("connection_node_fields", {}),
+                dm.ConnectionNode,
             )
         self.integrator = None
         self.processor = None

--- a/threedi_schematisation_editor/vector_data_importer/importers.py
+++ b/threedi_schematisation_editor/vector_data_importer/importers.py
@@ -23,9 +23,11 @@ from threedi_schematisation_editor.vector_data_importer.processors import (
     LineProcessor,
 )
 from threedi_schematisation_editor.vector_data_importer.settings_model import (
+    ConversionSettings,
     get_field_map_config,
 )
-from threedi_schematisation_editor.vector_data_importer.utils import ConversionSettings
+
+# from threedi_schematisation_editor.vector_data_importer.utils import ConversionSettings
 
 
 class Importer:
@@ -37,9 +39,7 @@ class Importer:
 
     @cached_property
     def conversion_settings(self):
-        # TODO: refactor
-        conversion_config = self.import_settings.get("conversion_settings", {})
-        return ConversionSettings(conversion_config)
+        return ConversionSettings(**self.import_settings.get("conversion_settings", {}))
 
     @cached_property
     def external_source_name(self):
@@ -243,11 +243,11 @@ class LinesImporter(SpatialImporter):
             self.fields_configurations,
             self.conversion_settings,
         )
-        if self.conversion_settings.integrate_channels:
+        if self.conversion_settings.edit_channels:
             self.integrator = ChannelIntegrator.from_importer(
                 conduit_layer, cross_section_location_layer, self
             )
-        elif self.conversion_settings.integrate_pipes and self.target_model_cls in [
+        elif self.conversion_settings.edit_pipes and self.target_model_cls in [
             dm.Weir,
             dm.Orifice,
         ]:

--- a/threedi_schematisation_editor/vector_data_importer/settings_model.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_model.py
@@ -1,0 +1,145 @@
+import inspect
+import json
+from dataclasses import fields
+from typing import Any, Dict, Optional, Type
+
+from pydantic import BaseModel, model_validator
+
+from threedi_schematisation_editor.vector_data_importer.utils import (
+    DEFAULT_INTERSECTION_BUFFER,
+    DEFAULT_MINIMUM_CHANNEL_LENGTH,
+    ColumnImportMethod,
+)
+
+
+class ConversionSettings(BaseModel):
+    """Model for the conversion_settings field"""
+
+    use_snapping: bool = False
+    snapping_distance: float = DEFAULT_INTERSECTION_BUFFER
+    minimum_channel_length: float = DEFAULT_MINIMUM_CHANNEL_LENGTH
+    create_connection_nodes: bool = False
+    edit_channels: bool = False
+    edit_pipes: bool = False
+    length_source_field: str = ""
+    length_fallback_value: float = 1.0
+    azimuth_source_field: str = ""
+    azimuth_fallback_value: float = 90.0
+    set_lowest_point_to_zero: bool = False
+    use_lowest_point_as_reference: bool = False
+    # These are odd fields because they actually use a field mapping
+    # In the new UI they will be moved to a field map, so for now we just validate
+    # that they are dicts
+    join_field_src: dict = {}
+    join_field_tgt: dict = {}
+    order_by_field: dict = {}
+
+
+class FieldMapConfig(BaseModel):
+    method: ColumnImportMethod
+    source_attribute: Optional[str] = None
+    expression: Optional[str] = None
+    default_value: Optional[Any] = None
+
+    @model_validator(mode="after")
+    def validate_required_fields(self) -> "FieldConfig":
+        method = self.method
+
+        # For expression method, expression is required
+        if method == ColumnImportMethod.EXPRESSION and not self.expression:
+            raise ValueError(
+                "When method is 'expression', 'expression' field is required"
+            )
+
+        # For default method, default_value is required
+        if method == ColumnImportMethod.DEFAULT and self.default_value is None:
+            raise ValueError(
+                "When method is 'default', 'default_value' field is required"
+            )
+
+        # For source_attribute method, source_attribute is required
+        if method == ColumnImportMethod.ATTRIBUTE and not self.source_attribute:
+            raise ValueError(
+                "When method is 'source_attribute', 'source_attribute' field is required"
+            )
+
+        return self
+
+
+class FieldsSectionValidator:
+    """Validator for a fields section against a dataclass."""
+
+    def __init__(self, dataclass_type: type, allow_empty: bool = False):
+        """
+        Initialize validator for a specific dataclass.
+
+        Args:
+            dataclass_type: The dataclass to validate against
+            allow_empty: If True, allows empty dictionary as valid input
+        """
+        self.dataclass_type = dataclass_type
+        self.expected_fields = {f.name for f in fields(dataclass_type)}
+        self.allow_empty = allow_empty
+
+    def validate(self, **fields_data) -> "FieldsSection":
+        """
+        Validate a fields section.
+
+        Args:
+            fields_data: Dictionary mapping field names to field configurations
+
+        Returns:
+            FieldsSection model with validated field configurations
+
+        Raises:
+            ValueError: If validation fails
+        """
+        # Allow empty dictionary if configured
+        if not fields_data and self.allow_empty:
+            return FieldsSection(fields={})
+
+        # First, validate each field configuration with Pydantic
+        validated_fields = {}
+        for field_name, field_config in fields_data.items():
+            if field_name not in self.expected_fields:
+                # ignore
+                continue
+            try:
+                validated_fields[field_name] = FieldMapConfig(**field_config)
+            except Exception as e:
+                raise ValueError(f"Invalid configuration for field '{field_name}': {e}")
+        return validated_fields
+
+
+# TODO consider how to use this
+class Settings:
+    def __init__(self, settings_file, fields_model, cn_model):
+        with open(settings_file, "r") as f:
+            config_json = json.load(f)
+        if "target_layer" not in config_json:
+            raise ValueError("Missing 'target_layer' in settings file")
+        self.target_layer = config_json["target_layer"]
+        self.conversion_settings = ConversionSettings(
+            **config_json.get("conversion_settings", {})
+        )
+        fields_validator = FieldsSectionValidator(fields_model)
+        self.fields = fields_validator.validate(**config_json["fields"])
+        cn_validator = FieldsSectionValidator(cn_model)
+        self.connection_nodes = cn_validator.validate(
+            **config_json["connection_node_fields"]
+        )
+
+
+def read_settings(settings_file: str, fields_model, cn_model) -> BaseModel:
+    with open(settings_file, "r") as f:
+        config_json = json.load(f)
+    if "target_layer" not in config_json:
+        raise ValueError("Missing 'target_layer' in settings file")
+    target_layer = config_json["target_layer"]
+    conversion_settings = ConversionSettings(
+        **config_json.get("conversion_settings", {})
+    )
+    fields_validator = FieldsSectionValidator(fields_model)
+    fields = fields_validator.validate(**config_json["fields"])
+    cn_validator = FieldsSectionValidator(cn_model)
+    cn = cn_validator.validate(**config_json["connection_node_fields"])

--- a/threedi_schematisation_editor/vector_data_importer/settings_model.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_model.py
@@ -1,7 +1,5 @@
-import inspect
-import json
 from dataclasses import fields
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional, Type
 
 from pydantic import BaseModel, model_validator
 
@@ -124,37 +122,3 @@ class FieldsSectionValidator:
 def get_field_map_config(field_config: dict, model_cls: Type):
     validator = FieldsSectionValidator(model_cls)
     return validator.validate(**field_config)
-
-
-# TODO consider how to use this
-class Settings:
-    def __init__(self, settings_file, fields_model, cn_model):
-        with open(settings_file, "r") as f:
-            config_json = json.load(f)
-        if "target_layer" not in config_json:
-            raise ValueError("Missing 'target_layer' in settings file")
-        self.target_layer = config_json["target_layer"]
-        self.conversion_settings = ConversionSettings(
-            **config_json.get("conversion_settings", {})
-        )
-        fields_validator = FieldsSectionValidator(fields_model)
-        self.fields = fields_validator.validate(**config_json["fields"])
-        cn_validator = FieldsSectionValidator(cn_model)
-        self.connection_nodes = cn_validator.validate(
-            **config_json["connection_node_fields"]
-        )
-
-
-def read_settings(settings_file: str, fields_model, cn_model) -> BaseModel:
-    with open(settings_file, "r") as f:
-        config_json = json.load(f)
-    if "target_layer" not in config_json:
-        raise ValueError("Missing 'target_layer' in settings file")
-    target_layer = config_json["target_layer"]
-    conversion_settings = ConversionSettings(
-        **config_json.get("conversion_settings", {})
-    )
-    fields_validator = FieldsSectionValidator(fields_model)
-    fields = fields_validator.validate(**config_json["fields"])
-    cn_validator = FieldsSectionValidator(cn_model)
-    cn = cn_validator.validate(**config_json["connection_node_fields"])

--- a/threedi_schematisation_editor/vector_data_importer/settings_model.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_model.py
@@ -77,17 +77,15 @@ class FieldMapConfig(BaseModel):
 class FieldsSectionValidator:
     """Validator for a fields section against a dataclass."""
 
-    def __init__(self, dataclass_type: type, allow_empty: bool = False):
+    def __init__(self, dataclass_type: type):
         """
         Initialize validator for a specific dataclass.
 
         Args:
             dataclass_type: The dataclass to validate against
-            allow_empty: If True, allows empty dictionary as valid input
         """
         self.dataclass_type = dataclass_type
         self.expected_fields = {f.name for f in fields(dataclass_type)}
-        self.allow_empty = allow_empty
 
     def validate(self, **fields_data) -> "FieldsSection":
         """
@@ -102,10 +100,6 @@ class FieldsSectionValidator:
         Raises:
             ValueError: If validation fails
         """
-        # Allow empty dictionary if configured
-        if not fields_data and self.allow_empty:
-            return FieldsSection(fields={})
-
         # First, validate each field configuration with Pydantic
         validated_fields = {}
         for field_name, field_config in fields_data.items():

--- a/threedi_schematisation_editor/vector_data_importer/settings_model.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_model.py
@@ -41,6 +41,16 @@ class FieldMapConfig(BaseModel):
     expression: Optional[str] = None
     default_value: Optional[Any] = None
 
+    # TODO: consider if we want to keep dict access support
+    def get(self, key, default=None):
+        return self.dict().get(key, default)
+
+    def __getitem__(self, item):
+        return self.dict().get(item)
+
+    def dict(self, **kwargs):
+        return super().dict(**kwargs)
+
     @model_validator(mode="after")
     def validate_required_fields(self) -> "FieldConfig":
         method = self.method
@@ -109,6 +119,11 @@ class FieldsSectionValidator:
             except Exception as e:
                 raise ValueError(f"Invalid configuration for field '{field_name}': {e}")
         return validated_fields
+
+
+def get_field_map_config(field_config: dict, model_cls: Type):
+    validator = FieldsSectionValidator(model_cls)
+    return validator.validate(**field_config)
 
 
 # TODO consider how to use this

--- a/threedi_schematisation_editor/vector_data_importer/utils.py
+++ b/threedi_schematisation_editor/vector_data_importer/utils.py
@@ -106,42 +106,6 @@ class FeatureManager:
             self.next_id += 1
 
 
-class ConversionSettings:
-    def __init__(self, conversion_config):
-        self.integrate_pipes = conversion_config.get("edit_pipes", False)
-        self.integrate_channels = conversion_config.get("edit_channels", False)
-        self.use_snapping = conversion_config.get("use_snapping", False)
-        if self.use_snapping:
-            self.snapping_distance = conversion_config.get("snapping_distance")
-        else:
-            self.snapping_distance = DEFAULT_INTERSECTION_BUFFER
-        self.minimum_channel_length = conversion_config.get(
-            "minimum_channel_length", DEFAULT_MINIMUM_CHANNEL_LENGTH
-        )
-        self.create_connection_nodes = conversion_config.get(
-            "create_connection_nodes", False
-        )
-        self.length_source_field = conversion_config.get("length_source_field", None)
-        self.length_fallback_value = conversion_config.get(
-            "length_fallback_value", 10.0
-        )
-        self.azimuth_source_field = conversion_config.get("azimuth_source_field", None)
-        self.azimuth_fallback_value = conversion_config.get(
-            "azimuth_fallback_value", 90.0
-        )
-        self.edit_channels = conversion_config.get("edit_channels", False)
-        self.join_field_src = conversion_config.get("join_field_src", None)
-        self.join_field_tgt = conversion_config.get("join_field_tgt", None)
-        self.group_by_field = conversion_config.get("group_by", None)
-        self.order_by_field = conversion_config.get("order_by", None)
-        self.set_lowest_point_to_zero = conversion_config.get(
-            "set_lowest_point_to_zero", False
-        )
-        self.use_lowest_point_as_reference = conversion_config.get(
-            "use_lowest_point_as_reference", False
-        )
-
-
 class ColumnImportMethod(Enum):
     AUTO = "auto"
     ATTRIBUTE = "source_attribute"


### PR DESCRIPTION
Add validation for the sections in the config files using existing data models and enums. This only affects parameter loading wehn creating an importer, downstream code is not affected for now. The idea behind this is to make it easier to validate parameters in the UI. In de upcoming wizard, each section of settings will correspond with a section in the config file and can thus be validated on its own. For the field mapping custom errors are used to easily identify the problem.

I kept the dict interactions with field mappings in tact to limit code changes. Curious to the reviewers opinion.

Note that this requires pydantic to be added to the dependency loader. For now the depency is hard-coded here to allow the tests to pass.