### PR TITLE
Actually upgrade gpkg schematisations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 -------------------
 
 - Fix incorrect QTableWidget method calls from `remove_row()` to `removeRow()` (nens/rana#3873)
+- Also upgrade geopackages upon loading (nens/threedi-schematisation-editor#486)
 
 
 2.4.9 (2026-03-13)

--- a/threedi_schematisation_editor/__init__.py
+++ b/threedi_schematisation_editor/__init__.py
@@ -367,33 +367,36 @@ class ThreediSchematisationEditorPlugin:
                 return
             model_gpkg = schematisation_filepath
 
-        if model_gpkg.endswith(".sqlite"):
-            QCoreApplication.processEvents()
-            migration_info = "Schema migration..."
-            self.uc.progress_bar(migration_info, 0, 100, 0, clear_msg_bar=True)
-            progress_bar_callback = progress_bar_callback_factory(self.uc)
-            migration_succeed, migration_feedback_msg = migrate_schematisation_schema(
-                model_gpkg, progress_bar_callback
-            )
-            self.uc.progress_bar("Migration complete!", 0, 100, 100, clear_msg_bar=True)
-            QCoreApplication.processEvents()
-            if len(migration_feedback_msg) > 0 and migration_succeed:
-                self.uc.show_info(migration_feedback_msg)
-                QgsMessageLog.logMessage(
-                    migration_feedback_msg, level=Qgis.Warning, tag="Messages"
-                )
-            elif not migration_succeed:
-                self.uc.clear_message_bar()
-                self.uc.show_warn(migration_feedback_msg)
-                return
-            model_gpkg = model_gpkg.rsplit(".", 1)[0] + ".gpkg"
-        elif model_gpkg.endswith(".gpkg"):
-            version_num = ThreediDatabase(model_gpkg).schema.get_version()
-            if version_num < 300:
-                warn_msg = "The selected file is not a valid Rana schematisation database.\n\nYou may have selected a geopackage that was created by an older version of the Rana Schematisation Editor (before version 2.0). In that case, there will probably be a Spatialite (*.sqlite) in the same folder. Please use that file instead."
-                self.uc.show_warn(warn_msg, None, "Rana Schematisation Editor")
-                return
+        version_num = ThreediDatabase(model_gpkg).schema.get_version()
+        # Valide file type and schema version combinations
+        if (model_gpkg.endswith(".sqlite") and version_num >= 300) or (
+            model_gpkg.endswith(".gpkg") and version_num < 300
+        ):
+            invalid_warn_msg = "The selected file is not a valid Rana schematisation database.\n\nYou may have selected a geopackage that was created by an older version of the Rana Schematisation Editor (before version 2.0). In that case, there will probably be a Spatialite (*.sqlite) in the same folder. Please use that file instead."
+            self.uc.show_warn(invalid_warn_msg, None, "Rana Schematisation Editor")
+            return
 
+        # Upgrade schematisation schema if needed
+        QCoreApplication.processEvents()
+        migration_info = "Schema migration..."
+        self.uc.progress_bar(migration_info, 0, 100, 0, clear_msg_bar=True)
+        progress_bar_callback = progress_bar_callback_factory(self.uc)
+        migration_succeed, migration_feedback_msg = migrate_schematisation_schema(
+            model_gpkg, progress_bar_callback
+        )
+        self.uc.progress_bar("Migration complete!", 0, 100, 100, clear_msg_bar=True)
+        QCoreApplication.processEvents()
+        if len(migration_feedback_msg) > 0 and migration_succeed:
+            self.uc.show_info(migration_feedback_msg)
+            QgsMessageLog.logMessage(
+                migration_feedback_msg, level=Qgis.Warning, tag="Messages"
+            )
+        elif not migration_succeed:
+            self.uc.clear_message_bar()
+            self.uc.show_warn(migration_feedback_msg)
+            return
+        if model_gpkg.endswith(".sqlite"):
+            model_gpkg = model_gpkg.rsplit(".", 1)[0] + ".gpkg"
         lm = LayersManager(self.iface, self.uc, model_gpkg, parents=parents)
         if lm in self.workspace_context_manager:
             self.uc.clear_message_bar()

--- a/threedi_schematisation_editor/__init__.py
+++ b/threedi_schematisation_editor/__init__.py
@@ -369,9 +369,7 @@ class ThreediSchematisationEditorPlugin:
 
         version_num = ThreediDatabase(model_gpkg).schema.get_version()
         # Valide file type and schema version combinations
-        if (model_gpkg.endswith(".sqlite") and version_num >= 300) or (
-            model_gpkg.endswith(".gpkg") and version_num < 300
-        ):
+        if model_gpkg.endswith(".gpkg") and version_num < 300:
             invalid_warn_msg = "The selected file is not a valid Rana schematisation database.\n\nYou may have selected a geopackage that was created by an older version of the Rana Schematisation Editor (before version 2.0). In that case, there will probably be a Spatialite (*.sqlite) in the same folder. Please use that file instead."
             self.uc.show_warn(invalid_warn_msg, None, "Rana Schematisation Editor")
             return

--- a/threedi_schematisation_editor/utils.py
+++ b/threedi_schematisation_editor/utils.py
@@ -801,30 +801,34 @@ def zoom_to_layer(layer: QgsMapLayer, iface: QgisInterface):
 
 def migrate_schematisation_schema(schematisation_filepath, progress_callback=None):
     """Migrate schematisation schema to the latest version."""
-    migration_succeed = False
     srid = None
-
+    can_migrate = False
+    migration_feedback_msg = ""
+    migration_succeed = False
     try:
         from threedi_schema import ThreediDatabase, errors
 
         backup_filepath = backup_schematisation_file(schematisation_filepath)
         threedi_db = ThreediDatabase(schematisation_filepath)
         schema = threedi_db.schema
-        srid, _ = schema._get_epsg_data()
-        if srid is None:
-            try:
-                srid = schema._get_dem_epsg()
-            except errors.InvalidSRIDException:
-                srid = None
-        if srid is None:
-            migration_feedback_msg = "Could not fetch valid EPSG code from database or DEM; aborting database migration."
+        if schema.get_version() < 230:
+            srid, _ = schema._get_epsg_data()
+            if srid is None:
+                try:
+                    srid = schema._get_dem_epsg()
+                except errors.InvalidSRIDException:
+                    srid = None
+            if srid is None:
+                migration_feedback_msg = "Could not fetch valid EPSG code from database or DEM; aborting database migration."
+            can_migrate = srid is not None
+        else:
+            can_migrate = True
     except ImportError:
         migration_feedback_msg = "Missing threedi-schema library (or its dependencies). Schema migration failed."
     except Exception as e:
         migration_feedback_msg = f"{e}"
 
-    if srid is not None:
-        migration_feedback_msg = ""
+    if can_migrate:
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always", UserWarning)


### PR DESCRIPTION
Upgrade was skipped for geopackages, this is now fixed. Also changed retrieving the srid, which is only needed for schematisation older than 230