### PR TITLE
Reject malformed import configs and invalid field mappings in importers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 
 - Add progress bar colors: blue while running, green on completion, red on failure (nens/rana-qgis-plugin#294)
 - Enforce .json suffix when saving importer presets to file (nens/threedi-schematisation-editor#493)
+- Validate settings files when importing via processing algorithm (nens/threedi-schematisation-editor#449)
 
 
 2.4.10 (2026-05-06)

--- a/tests/vector_data_importer/test_processing_algorithm.py
+++ b/tests/vector_data_importer/test_processing_algorithm.py
@@ -86,3 +86,23 @@ def test_threedi_import_rejects_invalid_field_method(
             task,
             feedback=QgsProcessingFeedback(),
         )
+
+
+def test_threedi_import_rejects_invalid_json(qgis_application_with_processor, tmp_path):
+    """Processing algorithm raises QgsProcessingException for malformed JSON."""
+    config_file = tmp_path / "bad.json"
+    config_file.write_text("this is not json{{{")
+
+    task = {
+        "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
+        "IMPORT_CONFIG": str(config_file),
+        "TARGET_GPKG": str(
+            get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
+        ),
+    }
+    with pytest.raises(QgsProcessingException, match="Could not read import config"):
+        processing.run(
+            "threedi_schematisation_editor:threedi_import_weirs",
+            task,
+            feedback=QgsProcessingFeedback(),
+        )

--- a/tests/vector_data_importer/test_processing_algorithm.py
+++ b/tests/vector_data_importer/test_processing_algorithm.py
@@ -1,8 +1,11 @@
+import copy
+import json
+
 import processing
 import pytest
 from processing.core.Processing import Processing
 from qgis.analysis import QgsNativeAlgorithms
-from qgis.core import QgsApplication, QgsProcessingFeedback
+from qgis.core import QgsApplication, QgsProcessingException, QgsProcessingFeedback
 
 from tests.utils import get_temp_copy
 from threedi_schematisation_editor.processing import (
@@ -57,3 +60,29 @@ def test_threedi_import_structure(qgis_application_with_processor):
         run_processing_operation("threedi_import_weirs", task)
     except Exception as e:
         pytest.fail(f"Test failed due to an unexpected exception: {e}")
+
+
+def test_threedi_import_rejects_invalid_field_method(
+    qgis_application_with_processor, tmp_path
+):
+    """Processing algorithm raises QgsProcessingException for a disallowed field method."""
+    with open(CONFIG_PATH / "import_weirs_nosnap.json") as f:
+        config = copy.deepcopy(json.load(f))
+    config["fields"]["id"] = {"method": "source_attribute", "source_attribute": "id"}
+
+    config_file = tmp_path / "invalid_config.json"
+    config_file.write_text(json.dumps(config))
+
+    task = {
+        "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
+        "IMPORT_CONFIG": str(config_file),
+        "TARGET_GPKG": str(
+            get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
+        ),
+    }
+    with pytest.raises(QgsProcessingException, match="Invalid field map"):
+        processing.run(
+            "threedi_schematisation_editor:threedi_import_weirs",
+            task,
+            feedback=QgsProcessingFeedback(),
+        )

--- a/tests/vector_data_importer/test_processing_algorithm.py
+++ b/tests/vector_data_importer/test_processing_algorithm.py
@@ -62,57 +62,60 @@ def test_threedi_import_structure(qgis_application_with_processor):
         pytest.fail(f"Test failed due to an unexpected exception: {e}")
 
 
-def test_threedi_import_rejects_invalid_field_method(
-    qgis_application_with_processor, tmp_path
+@pytest.mark.parametrize(
+    "config_patch,expected_match",
+    [
+        # Disallowed method for a 'fields' entry (id only allows AUTO)
+        (
+            {
+                "fields": {
+                    "id": {"method": "source_attribute", "source_attribute": "id"}
+                }
+            },
+            "Invalid field map \\(fields\\)",
+        ),
+        # Disallowed method for a 'connection_node_fields' entry (id only allows AUTO)
+        (
+            {
+                "connection_node_fields": {
+                    "id": {"method": "source_attribute", "source_attribute": "id"}
+                }
+            },
+            "Invalid field map \\(connection_node_fields\\)",
+        ),
+        # Invalid ImportSettings schema: snap_distance must be a float
+        (
+            {"connection_nodes": {"snap_distance": "not_a_number"}},
+            "Invalid import settings",
+        ),
+    ],
+)
+def test_threedi_import_rejects_invalid_config(
+    qgis_application_with_processor, tmp_path, config_patch, expected_match
 ):
-    """Processing algorithm raises QgsProcessingException for a disallowed field method."""
+    """Processing algorithm raises QgsProcessingException for invalid import configs."""
     with open(CONFIG_PATH / "import_weirs_nosnap.json") as f:
         config = copy.deepcopy(json.load(f))
-    config["fields"]["id"] = {"method": "source_attribute", "source_attribute": "id"}
+
+    for key, value in config_patch.items():
+        if isinstance(value, dict) and isinstance(config.get(key), dict):
+            config[key].update(value)
+        else:
+            config[key] = value
 
     config_file = tmp_path / "invalid_config.json"
     config_file.write_text(json.dumps(config))
 
-    task = {
-        "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
-        "IMPORT_CONFIG": str(config_file),
-        "TARGET_GPKG": str(
-            get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
-        ),
-    }
-    with pytest.raises(QgsProcessingException, match="Invalid field map"):
+    with pytest.raises(QgsProcessingException, match=expected_match):
         processing.run(
             "threedi_schematisation_editor:threedi_import_weirs",
-            task,
-            feedback=QgsProcessingFeedback(),
-        )
-
-
-def test_threedi_import_rejects_invalid_connection_node_field_method(
-    qgis_application_with_processor, tmp_path
-):
-    """Processing algorithm raises QgsProcessingException for a disallowed connection_node_fields method."""
-    with open(CONFIG_PATH / "import_weirs_nosnap.json") as f:
-        config = copy.deepcopy(json.load(f))
-    config["connection_node_fields"]["id"] = {
-        "method": "source_attribute",
-        "source_attribute": "id",
-    }
-
-    config_file = tmp_path / "invalid_cn_config.json"
-    config_file.write_text(json.dumps(config))
-
-    task = {
-        "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
-        "IMPORT_CONFIG": str(config_file),
-        "TARGET_GPKG": str(
-            get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
-        ),
-    }
-    with pytest.raises(QgsProcessingException, match="Invalid field map"):
-        processing.run(
-            "threedi_schematisation_editor:threedi_import_weirs",
-            task,
+            {
+                "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
+                "IMPORT_CONFIG": str(config_file),
+                "TARGET_GPKG": str(
+                    get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
+                ),
+            },
             feedback=QgsProcessingFeedback(),
         )
 
@@ -122,16 +125,15 @@ def test_threedi_import_rejects_invalid_json(qgis_application_with_processor, tm
     config_file = tmp_path / "bad.json"
     config_file.write_text("this is not json{{{")
 
-    task = {
-        "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
-        "IMPORT_CONFIG": str(config_file),
-        "TARGET_GPKG": str(
-            get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
-        ),
-    }
     with pytest.raises(QgsProcessingException, match="Could not read import config"):
         processing.run(
             "threedi_schematisation_editor:threedi_import_weirs",
-            task,
+            {
+                "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
+                "IMPORT_CONFIG": str(config_file),
+                "TARGET_GPKG": str(
+                    get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
+                ),
+            },
             feedback=QgsProcessingFeedback(),
         )

--- a/tests/vector_data_importer/test_processing_algorithm.py
+++ b/tests/vector_data_importer/test_processing_algorithm.py
@@ -88,6 +88,35 @@ def test_threedi_import_rejects_invalid_field_method(
         )
 
 
+def test_threedi_import_rejects_invalid_connection_node_field_method(
+    qgis_application_with_processor, tmp_path
+):
+    """Processing algorithm raises QgsProcessingException for a disallowed connection_node_fields method."""
+    with open(CONFIG_PATH / "import_weirs_nosnap.json") as f:
+        config = copy.deepcopy(json.load(f))
+    config["connection_node_fields"]["id"] = {
+        "method": "source_attribute",
+        "source_attribute": "id",
+    }
+
+    config_file = tmp_path / "invalid_cn_config.json"
+    config_file.write_text(json.dumps(config))
+
+    task = {
+        "SOURCE_LAYER": str(get_temp_copy(SOURCE_PATH / "weirs.gpkg")),
+        "IMPORT_CONFIG": str(config_file),
+        "TARGET_GPKG": str(
+            get_temp_copy(SCHEMATISATION_PATH / "schematisation_channel.gpkg")
+        ),
+    }
+    with pytest.raises(QgsProcessingException, match="Invalid field map"):
+        processing.run(
+            "threedi_schematisation_editor:threedi_import_weirs",
+            task,
+            feedback=QgsProcessingFeedback(),
+        )
+
+
 def test_threedi_import_rejects_invalid_json(qgis_application_with_processor, tmp_path):
     """Processing algorithm raises QgsProcessingException for malformed JSON."""
     config_file = tmp_path / "bad.json"

--- a/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
+++ b/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
@@ -15,6 +15,7 @@ from qgis.core import (
 )
 from qgis.PyQt.QtCore import QCoreApplication
 
+import threedi_schematisation_editor.data_models as dm
 from threedi_schematisation_editor.vector_data_importer.importers import (
     ChannelsImporter,
     ConnectionNodesImporter,
@@ -32,6 +33,35 @@ from threedi_schematisation_editor.vector_data_importer.settings_models import (
 )
 
 
+def load_import_settings(file_path, model_cls):
+    """Load and fully validate import settings from a JSON file.
+
+    Handles JSON parse errors, ImportSettings validation, and field map
+    validation against the target model class.
+    Raises QgsProcessingException on any failure.
+    """
+    try:
+        with open(file_path) as f:
+            import_settings_dict = json.loads(f.read())
+    except (OSError, json.JSONDecodeError) as e:
+        raise QgsProcessingException(
+            f"Could not read import config {file_path}: {e}"
+        ) from e
+
+    try:
+        import_config = ImportSettings(**import_settings_dict)
+    except ValidationError as e:
+        raise QgsProcessingException(f"Invalid import settings: {e}") from e
+
+    if model_cls is not None:
+        try:
+            validate_field_map(import_config.fields, model_cls)
+        except ValidationError as e:
+            raise QgsProcessingException(f"Invalid field map settings: {e}") from e
+
+    return import_config
+
+
 class BaseImporter(QgsProcessingAlgorithm):
     """Base class for all importers."""
 
@@ -39,6 +69,7 @@ class BaseImporter(QgsProcessingAlgorithm):
     IMPORT_CONFIG = "IMPORT_CONFIG"
     TARGET_GPKG = "TARGET_GPKG"
     FEATURE_TYPE = ""  # To be overridden by subclasses
+    target_model_cls = None  # Override in subclasses that have a single target model
 
     def createInstance(self):
         return self.__class__()
@@ -146,20 +177,9 @@ class BaseImporter(QgsProcessingAlgorithm):
                 self.invalidSourceError(parameters, self.TARGET_GPKG)
             )
 
-        with open(import_config_file) as import_config_json:
-            import_settings_dict = json.loads(import_config_json.read())
-        try:
-            import_config = ImportSettings(**import_settings_dict)
-        except ValidationError as e:
-            raise QgsProcessingException(f"Invalid import settings: {e}") from e
+        import_config = load_import_settings(import_config_file, self.target_model_cls)
 
         importer = self.create_importer(source_layer, target_gpkg, import_config)
-        target_model_cls = getattr(importer, "target_model_cls", None)
-        if target_model_cls is not None:
-            try:
-                validate_field_map(import_config.fields, target_model_cls)
-            except ValidationError as e:
-                raise QgsProcessingException(f"Invalid field map settings: {e}") from e
 
         # Use the right import method based on the importer type
         importer.import_features(context=context)
@@ -178,7 +198,8 @@ class ImportConnectionNodes(SimpleImporter):
     """Import connection nodes."""
 
     IMPORTER_CLASS = ConnectionNodesImporter
-    FEATURE_TYPE = "connection_node"  # To be overridden by subclasses
+    FEATURE_TYPE = "connection_node"
+    target_model_cls = dm.ConnectionNode
 
     def get_source_layer_types(self):
         return [QgsProcessing.TypeVectorPoint]
@@ -189,6 +210,7 @@ class ImportPipes(SimpleImporter):
 
     IMPORTER_CLASS = PipesImporter
     FEATURE_TYPE = "pipe"
+    target_model_cls = dm.Pipe
 
 
 class ImportChannels(SimpleImporter):
@@ -196,6 +218,7 @@ class ImportChannels(SimpleImporter):
 
     IMPORTER_CLASS = ChannelsImporter
     FEATURE_TYPE = "channel"
+    target_model_cls = dm.Channel
 
 
 class StructureImporter(BaseImporter):
@@ -218,6 +241,7 @@ class ImportCulverts(StructureImporter):
     FEATURE_TYPE = "culvert"
     IMPORTER_CLASS = CulvertsImporter
     INTEGRATOR_CLASS = CulvertsImporter
+    target_model_cls = dm.Culvert
 
 
 class ImportOrifices(StructureImporter):
@@ -226,6 +250,7 @@ class ImportOrifices(StructureImporter):
     FEATURE_TYPE = "orifice"
     IMPORTER_CLASS = OrificesImporter
     INTEGRATOR_CLASS = OrificesImporter
+    target_model_cls = dm.Orifice
 
 
 class ImportWeirs(StructureImporter):
@@ -234,11 +259,13 @@ class ImportWeirs(StructureImporter):
     FEATURE_TYPE = "weir"
     IMPORTER_CLASS = WeirsImporter
     INTEGRATOR_CLASS = WeirsImporter
+    target_model_cls = dm.Weir
 
 
 class ImportCrossSectionLocation(SimpleImporter):
     IMPORTER_CLASS = CrossSectionLocationImporter
     FEATURE_TYPE = "cross_section_location"
+    target_model_cls = dm.CrossSectionLocation
 
     def get_source_layer_types(self):
         return [

--- a/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
+++ b/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
@@ -43,7 +43,7 @@ def load_import_settings(file_path, model_cls, connection_node_model_cls=None):
     """
     try:
         with open(file_path) as f:
-            import_settings_dict = json.loads(f.read())
+            import_settings_dict = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         raise QgsProcessingException(
             f"Could not read import config {file_path}: {e}"
@@ -58,7 +58,7 @@ def load_import_settings(file_path, model_cls, connection_node_model_cls=None):
         try:
             validate_field_map(import_config.fields, model_cls)
         except ValidationError as e:
-            raise QgsProcessingException(f"Invalid field map: {e}") from e
+            raise QgsProcessingException(f"Invalid field map (fields): {e}") from e
 
     if connection_node_model_cls is not None:
         try:
@@ -66,7 +66,9 @@ def load_import_settings(file_path, model_cls, connection_node_model_cls=None):
                 import_config.connection_node_fields, connection_node_model_cls
             )
         except ValidationError as e:
-            raise QgsProcessingException(f"Invalid field map: {e}") from e
+            raise QgsProcessingException(
+                f"Invalid field map (connection_node_fields): {e}"
+            ) from e
 
     return import_config
 
@@ -295,6 +297,8 @@ class ImportCrossSectionLocation(SimpleImporter):
 class ImportCrossSectionData(SimpleImporter):
     IMPORTER_CLASS = CrossSectionDataImporter
     FEATURE_TYPE = "cross_section_data"
+    # TARGET_MODEL_CLS is intentionally not set: CrossSectionData is a virtual
+    # import-only class with no single target model.
 
     def get_source_layer_types(self):
         return [

--- a/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
+++ b/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
@@ -33,11 +33,12 @@ from threedi_schematisation_editor.vector_data_importer.settings_models import (
 )
 
 
-def load_import_settings(file_path, model_cls):
+def load_import_settings(file_path, model_cls, connection_node_model_cls=None):
     """Load and fully validate import settings from a JSON file.
 
     Handles JSON parse errors, ImportSettings validation, and field map
-    validation against the target model class.
+    validation against the target model class and (optionally) the connection
+    node model class.
     Raises QgsProcessingException on any failure.
     """
     try:
@@ -57,7 +58,15 @@ def load_import_settings(file_path, model_cls):
         try:
             validate_field_map(import_config.fields, model_cls)
         except ValidationError as e:
-            raise QgsProcessingException(f"Invalid field map settings: {e}") from e
+            raise QgsProcessingException(f"Invalid field map: {e}") from e
+
+    if connection_node_model_cls is not None:
+        try:
+            validate_field_map(
+                import_config.connection_node_fields, connection_node_model_cls
+            )
+        except ValidationError as e:
+            raise QgsProcessingException(f"Invalid field map: {e}") from e
 
     return import_config
 
@@ -69,7 +78,10 @@ class BaseImporter(QgsProcessingAlgorithm):
     IMPORT_CONFIG = "IMPORT_CONFIG"
     TARGET_GPKG = "TARGET_GPKG"
     FEATURE_TYPE = ""  # To be overridden by subclasses
-    target_model_cls = None  # Override in subclasses that have a single target model
+    TARGET_MODEL_CLS = None  # Override in subclasses that have a single target model
+    CONNECTION_NODE_MODEL_CLS = (
+        None  # Override in subclasses that validate connection_node_fields
+    )
 
     def createInstance(self):
         return self.__class__()
@@ -177,7 +189,9 @@ class BaseImporter(QgsProcessingAlgorithm):
                 self.invalidSourceError(parameters, self.TARGET_GPKG)
             )
 
-        import_config = load_import_settings(import_config_file, self.target_model_cls)
+        import_config = load_import_settings(
+            import_config_file, self.TARGET_MODEL_CLS, self.CONNECTION_NODE_MODEL_CLS
+        )
 
         importer = self.create_importer(source_layer, target_gpkg, import_config)
 
@@ -199,7 +213,7 @@ class ImportConnectionNodes(SimpleImporter):
 
     IMPORTER_CLASS = ConnectionNodesImporter
     FEATURE_TYPE = "connection_node"
-    target_model_cls = dm.ConnectionNode
+    TARGET_MODEL_CLS = dm.ConnectionNode
 
     def get_source_layer_types(self):
         return [QgsProcessing.TypeVectorPoint]
@@ -210,7 +224,7 @@ class ImportPipes(SimpleImporter):
 
     IMPORTER_CLASS = PipesImporter
     FEATURE_TYPE = "pipe"
-    target_model_cls = dm.Pipe
+    TARGET_MODEL_CLS = dm.Pipe
 
 
 class ImportChannels(SimpleImporter):
@@ -218,7 +232,7 @@ class ImportChannels(SimpleImporter):
 
     IMPORTER_CLASS = ChannelsImporter
     FEATURE_TYPE = "channel"
-    target_model_cls = dm.Channel
+    TARGET_MODEL_CLS = dm.Channel
 
 
 class StructureImporter(BaseImporter):
@@ -241,7 +255,8 @@ class ImportCulverts(StructureImporter):
     FEATURE_TYPE = "culvert"
     IMPORTER_CLASS = CulvertsImporter
     INTEGRATOR_CLASS = CulvertsImporter
-    target_model_cls = dm.Culvert
+    TARGET_MODEL_CLS = dm.Culvert
+    CONNECTION_NODE_MODEL_CLS = dm.ConnectionNode
 
 
 class ImportOrifices(StructureImporter):
@@ -250,7 +265,8 @@ class ImportOrifices(StructureImporter):
     FEATURE_TYPE = "orifice"
     IMPORTER_CLASS = OrificesImporter
     INTEGRATOR_CLASS = OrificesImporter
-    target_model_cls = dm.Orifice
+    TARGET_MODEL_CLS = dm.Orifice
+    CONNECTION_NODE_MODEL_CLS = dm.ConnectionNode
 
 
 class ImportWeirs(StructureImporter):
@@ -259,13 +275,14 @@ class ImportWeirs(StructureImporter):
     FEATURE_TYPE = "weir"
     IMPORTER_CLASS = WeirsImporter
     INTEGRATOR_CLASS = WeirsImporter
-    target_model_cls = dm.Weir
+    TARGET_MODEL_CLS = dm.Weir
+    CONNECTION_NODE_MODEL_CLS = dm.ConnectionNode
 
 
 class ImportCrossSectionLocation(SimpleImporter):
     IMPORTER_CLASS = CrossSectionLocationImporter
     FEATURE_TYPE = "cross_section_location"
-    target_model_cls = dm.CrossSectionLocation
+    TARGET_MODEL_CLS = dm.CrossSectionLocation
 
     def get_source_layer_types(self):
         return [

--- a/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
+++ b/threedi_schematisation_editor/processing/algorithms_vector_data_importer.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 by Nelen & Schuurmans
 import json
 
+from pydantic import ValidationError
 from qgis.core import (
     QgsProcessing,
     QgsProcessingAlgorithm,
@@ -27,6 +28,7 @@ from threedi_schematisation_editor.vector_data_importer.importers import (
 from threedi_schematisation_editor.vector_data_importer.settings_models import (
     ImportSettings,
     IntegrationMode,
+    validate_field_map,
 )
 
 
@@ -146,9 +148,18 @@ class BaseImporter(QgsProcessingAlgorithm):
 
         with open(import_config_file) as import_config_json:
             import_settings_dict = json.loads(import_config_json.read())
-        import_config = ImportSettings(**import_settings_dict)
+        try:
+            import_config = ImportSettings(**import_settings_dict)
+        except ValidationError as e:
+            raise QgsProcessingException(f"Invalid import settings: {e}") from e
 
         importer = self.create_importer(source_layer, target_gpkg, import_config)
+        target_model_cls = getattr(importer, "target_model_cls", None)
+        if target_model_cls is not None:
+            try:
+                validate_field_map(import_config.fields, target_model_cls)
+            except ValidationError as e:
+                raise QgsProcessingException(f"Invalid field map settings: {e}") from e
 
         # Use the right import method based on the importer type
         importer.import_features(context=context)

--- a/threedi_schematisation_editor/vector_data_importer/settings_models.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_models.py
@@ -53,9 +53,6 @@ class ConnectionNodeSettings(BaseModel):
     snap: bool = True
     snap_distance: float = Field(default=1.0, ge=0, le=1000000.0)
 
-    def serialize(self):
-        return asdict(self)
-
 
 class IntegrationSettings(BaseModel):
     # class variables used to identify model

--- a/threedi_schematisation_editor/vector_data_importer/settings_models.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_models.py
@@ -160,6 +160,24 @@ def get_field_map_config_for_model_class_field(
     )
 
 
+def validate_field_map(field_map: dict, model_cls: Type) -> dict:
+    """Validate a field map dict against a target data model class.
+
+    Re-validates each entry using the custom FieldMapConfig subclass for that
+    field, which enforces the correct allowed methods and required fields.
+    Fields not present on the model class are silently skipped.
+    Raises ValidationError if any entry is invalid.
+    """
+    model_field_names = {f.name for f in fields(model_cls)}
+    return {
+        field_name: get_field_map_config_for_model_class_field(field_name, model_cls)(
+            **field_data
+        )
+        for field_name, field_data in field_map.items()
+        if field_name in model_field_names
+    }
+
+
 def get_allowed_methods_for_model_class_field(
     model_field,
 ) -> list[ColumnImportMethod]:

--- a/threedi_schematisation_editor/vector_data_importer/settings_models.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_models.py
@@ -160,7 +160,7 @@ def get_field_map_config_for_model_class_field(
     )
 
 
-def validate_field_map(field_map: dict, model_cls: Type) -> dict:
+def validate_field_map(field_map: dict, model_cls: Type) -> None:
     """Validate a field map dict against a target data model class.
 
     Re-validates each entry using the custom FieldMapConfig subclass for that
@@ -169,13 +169,14 @@ def validate_field_map(field_map: dict, model_cls: Type) -> dict:
     Raises ValidationError if any entry is invalid.
     """
     model_field_names = {f.name for f in fields(model_cls)}
-    return {
-        field_name: get_field_map_config_for_model_class_field(field_name, model_cls)(
-            **field_data if isinstance(field_data, dict) else field_data.model_dump()
+    for field_name, field_data in field_map.items():
+        if field_name not in model_field_names:
+            continue
+        field_cfg_cls = get_field_map_config_for_model_class_field(
+            field_name, model_cls
         )
-        for field_name, field_data in field_map.items()
-        if field_name in model_field_names
-    }
+        kwargs = field_data if isinstance(field_data, dict) else field_data.model_dump()
+        field_cfg_cls(**kwargs)
 
 
 def get_allowed_methods_for_model_class_field(

--- a/threedi_schematisation_editor/vector_data_importer/settings_models.py
+++ b/threedi_schematisation_editor/vector_data_importer/settings_models.py
@@ -171,7 +171,7 @@ def validate_field_map(field_map: dict, model_cls: Type) -> dict:
     model_field_names = {f.name for f in fields(model_cls)}
     return {
         field_name: get_field_map_config_for_model_class_field(field_name, model_cls)(
-            **field_data
+            **field_data if isinstance(field_data, dict) else field_data.model_dump()
         )
         for field_name, field_data in field_map.items()
         if field_name in model_field_names


### PR DESCRIPTION
Added runtime validation for import configuration files and field maps so import algorithms fail fast on bad input.

- New validate_field_map() in vector_data_importer.settings_models to re-validate each field entry against the target data model.
- New load_import_settings() in processing/algorithms_vector_data_importer to read JSON, validate ImportSettings (pydantic) and validate the field map; converts JSON/validation errors into QgsProcessingException.
- Importer classes now declare target_model_cls where applicable so field maps can be checked against the correct model.
- Tests updated/added to assert the processing algorithm raises QgsProcessingException for malformed JSON and for disallowed field methods.

This prevents imports from proceeding with invalid configs and surfaces clearer error messages to callers.

Closes https://github.com/nens/threedi-schematisation-editor/issues/449