### PR TITLE
Support optional reference level for cross-section locations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ History
 - Validate settings files when importing via processing algorithm (nens/threedi-schematisation-editor#449)
 - Skip integration (with warning) when object matches to multiple conduits (nens/threedi-schematisation-editor#409)
 - Fix structures outside conduit raw bounding box not being matched despite being within snapping distance
+- Add reference_level field for cross section location import (nens/rana#3644)
 
 
 2.4.10 (2026-05-06)

--- a/threedi_schematisation_editor/data_models.py
+++ b/threedi_schematisation_editor/data_models.py
@@ -421,6 +421,7 @@ class CrossSectionLocation(ModelObject):
     friction_type: Optional[FrictionType]
     friction_value: float
     bank_level: Optional[float]
+    reference_level: Optional[float]
     channel_id: int = field(metadata={ALLOWED_METHODS_FIELD: [ColumnImportMethod.AUTO]})
     cross_section_shape: Optional[CrossSectionShape]
     cross_section_width: Optional[float] = field(metadata={DISPLAY_UNIT_FIELD: "m"})


### PR DESCRIPTION
Added an optional `reference_level` field to the CrossSectionLocation data model

Closes nens/rana#3644