### PR TITLE
Preserve existing field-map config object when loading JSON

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ History
 - Validate settings files when importing via processing algorithm (nens/threedi-schematisation-editor#449)
 - Skip integration (with warning) when object matches to multiple conduits (nens/threedi-schematisation-editor#409)
 - Fix structures outside conduit raw bounding box not being matched despite being within snapping distance
+- Fix loading import settings; affects: point_to_line_conversion.lenght, point_to_line_conversion.azimuth, cross_section_location_mapping.join_field_src, join_field_src.join_field_tgt (nens/threedi-schematisation-editor#473)
+- Correct azimuth units in UI (was 'm', should be °)
 
 
 2.4.10 (2026-05-06)

--- a/threedi_schematisation_editor/vector_data_importer/wizard/field_map.py
+++ b/threedi_schematisation_editor/vector_data_importer/wizard/field_map.py
@@ -137,7 +137,11 @@ class FieldMapRow:
         # Get the custom config class that has the validation, including allowed methods
         config_class = self.config.__class__
         # Use the custom class (CustomFieldMapConfig) for deserialization
-        self.config = config_class(**data)
+        new_config = config_class(**data)
+        # Update the existing config in place to preserve any external references
+        # (e.g. FieldMapSettingsWidget.model.length points to the same object)
+        for field_name in config_class.model_fields:
+            setattr(self.config, field_name, getattr(new_config, field_name))
 
     @property
     def is_valid(self) -> bool:

--- a/threedi_schematisation_editor/vector_data_importer/wizard/settings_widgets.py
+++ b/threedi_schematisation_editor/vector_data_importer/wizard/settings_widgets.py
@@ -368,7 +368,7 @@ class PointToLIneConversionSettingsWidget(FieldMapSettingsWidget):
         }
         self.setup_ui(row_dict)
         self.field_map_widget.table_model.set_default_value_units("length", " m")
-        self.field_map_widget.table_model.set_default_value_units("azimuth", " m")
+        self.field_map_widget.table_model.set_default_value_units("azimuth", " °")
 
     @property
     def group_name(self):


### PR DESCRIPTION
Update the existing config's attributes from the deserialized data instead of replacing the config object, preserving external references used by UI widgets (e.g. FieldMapSettingsWidget.model.length). This seems to have affected:
* Point to line conversion: length and azimuth
* Cross section location: join settings

Closes #477